### PR TITLE
Fix relation attributes with arguments

### DIFF
--- a/src/Attributes/Relations/BelongsTo.php
+++ b/src/Attributes/Relations/BelongsTo.php
@@ -20,15 +20,15 @@ final class BelongsTo implements RelationAttribute
     public string $relationClass;
 
     /**
-     * @var array<mixed>
+     * @var array<string>
      */
     public array $arguments = [];
 
     /**
      * @param  class-string  $relationClass
-     * @param  array<mixed>  ...$arguments
+     * @param  array<string>  ...$arguments
      */
-    public function __construct(string $relationClass, array ...$arguments)
+    public function __construct(string $relationClass, string ...$arguments)
     {
         $this->relationClass = $relationClass;
         $this->arguments = [$relationClass, ...$arguments];
@@ -41,6 +41,6 @@ final class BelongsTo implements RelationAttribute
 
     public function relationName(): string
     {
-        return Str::singular(mb_strtolower(class_basename($this->relationClass)));
+        return Str::singular(Str::camel(class_basename($this->relationClass)));
     }
 }

--- a/src/Attributes/Relations/BelongsToMany.php
+++ b/src/Attributes/Relations/BelongsToMany.php
@@ -20,15 +20,15 @@ final class BelongsToMany implements RelationAttribute
     public string $relationClass;
 
     /**
-     * @var array<mixed>
+     * @var array<string>
      */
     public array $arguments = [];
 
     /**
      * @param  class-string  $relationClass
-     * @param  array<mixed>  ...$arguments
+     * @param  array<string>  ...$arguments
      */
-    public function __construct(string $relationClass, array ...$arguments)
+    public function __construct(string $relationClass, string ...$arguments)
     {
         $this->relationClass = $relationClass;
         $this->arguments = [$relationClass, ...$arguments];
@@ -36,6 +36,6 @@ final class BelongsToMany implements RelationAttribute
 
     public function relationName(): string
     {
-        return Str::plural(mb_strtolower(class_basename($this->relationClass)));
+        return Str::plural(Str::camel(class_basename($this->relationClass)));
     }
 }

--- a/src/Attributes/Relations/HasMany.php
+++ b/src/Attributes/Relations/HasMany.php
@@ -20,15 +20,15 @@ final class HasMany implements RelationAttribute
     public string $relationClass;
 
     /**
-     * @var array<mixed>
+     * @var array<string>
      */
     public array $arguments = [];
 
     /**
      * @param  class-string  $relationClass
-     * @param  array<mixed>  ...$arguments
+     * @param  array<string>  ...$arguments
      */
-    public function __construct(string $relationClass, array ...$arguments)
+    public function __construct(string $relationClass, string ...$arguments)
     {
         $this->relationClass = $relationClass;
         $this->arguments = [$relationClass, ...$arguments];
@@ -36,6 +36,6 @@ final class HasMany implements RelationAttribute
 
     public function relationName(): string
     {
-        return Str::plural(mb_strtolower(class_basename($this->relationClass)));
+        return Str::plural(Str::camel(class_basename($this->relationClass)));
     }
 }

--- a/src/Attributes/Relations/HasManyThrough.php
+++ b/src/Attributes/Relations/HasManyThrough.php
@@ -25,7 +25,7 @@ final class HasManyThrough implements RelationAttribute
     public string $throughClass;
 
     /**
-     * @var array<string>
+     * @var array<string|class-string>
      */
     public array $arguments = [];
 

--- a/src/Attributes/Relations/HasManyThrough.php
+++ b/src/Attributes/Relations/HasManyThrough.php
@@ -25,16 +25,16 @@ final class HasManyThrough implements RelationAttribute
     public string $throughClass;
 
     /**
-     * @var array<mixed>
+     * @var array<string>
      */
     public array $arguments = [];
 
     /**
      * @param  class-string  $relationClass
      * @param  class-string  $throughClass
-     * @param  array<mixed>  ...$arguments
+     * @param  array<string>  ...$arguments
      */
-    public function __construct(string $relationClass, string $throughClass, array ...$arguments)
+    public function __construct(string $relationClass, string $throughClass, string ...$arguments)
     {
         $this->relationClass = $relationClass;
         $this->throughClass = $throughClass;
@@ -43,6 +43,6 @@ final class HasManyThrough implements RelationAttribute
 
     public function relationName(): string
     {
-        return Str::plural(mb_strtolower(class_basename($this->relationClass)));
+        return Str::plural(Str::camel(class_basename($this->relationClass)));
     }
 }

--- a/src/Attributes/Relations/HasOne.php
+++ b/src/Attributes/Relations/HasOne.php
@@ -20,15 +20,15 @@ final class HasOne implements RelationAttribute
     public string $relationClass;
 
     /**
-     * @var array<mixed>
+     * @var array<string>
      */
     public array $arguments = [];
 
     /**
      * @param  class-string  $relationClass
-     * @param  array<mixed>  ...$arguments
+     * @param  array<string>  ...$arguments
      */
-    public function __construct(string $relationClass, array ...$arguments)
+    public function __construct(string $relationClass, string ...$arguments)
     {
         $this->relationClass = $relationClass;
         $this->arguments = [$relationClass, ...$arguments];
@@ -36,6 +36,6 @@ final class HasOne implements RelationAttribute
 
     public function relationName(): string
     {
-        return Str::singular(mb_strtolower(class_basename($this->relationClass)));
+        return Str::singular(Str::camel(class_basename($this->relationClass)));
     }
 }

--- a/src/Attributes/Relations/HasOneThrough.php
+++ b/src/Attributes/Relations/HasOneThrough.php
@@ -25,14 +25,14 @@ final class HasOneThrough implements RelationAttribute
     public string $throughClass;
 
     /**
-     * @var array<mixed>
+     * @var array<string>
      */
     public array $arguments = [];
 
     /**
      * @param  class-string  $relationClass
      * @param  class-string  $throughClass
-     * @param  array<mixed>  ...$arguments
+     * @param  array<string>  ...$arguments
      */
     public function __construct(string $relationClass, string $throughClass, array ...$arguments)
     {
@@ -43,6 +43,6 @@ final class HasOneThrough implements RelationAttribute
 
     public function relationName(): string
     {
-        return Str::singular(mb_strtolower(class_basename($this->relationClass)));
+        return Str::singular(Str::camel(class_basename($this->relationClass)));
     }
 }

--- a/src/Attributes/Relations/HasOneThrough.php
+++ b/src/Attributes/Relations/HasOneThrough.php
@@ -25,7 +25,7 @@ final class HasOneThrough implements RelationAttribute
     public string $throughClass;
 
     /**
-     * @var array<string>
+     * @var array<string|class-string>
      */
     public array $arguments = [];
 
@@ -34,7 +34,7 @@ final class HasOneThrough implements RelationAttribute
      * @param  class-string  $throughClass
      * @param  array<string>  ...$arguments
      */
-    public function __construct(string $relationClass, string $throughClass, array ...$arguments)
+    public function __construct(string $relationClass, string $throughClass, string ...$arguments)
     {
         $this->relationClass = $relationClass;
         $this->throughClass = $throughClass;

--- a/src/Attributes/Relations/MorphMany.php
+++ b/src/Attributes/Relations/MorphMany.php
@@ -22,7 +22,7 @@ final class MorphMany implements RelationAttribute
     public string $morphName;
 
     /**
-     * @var array<string>
+     * @var array<string|class-string>
      */
     public array $arguments = [];
 

--- a/src/Attributes/Relations/MorphMany.php
+++ b/src/Attributes/Relations/MorphMany.php
@@ -22,15 +22,15 @@ final class MorphMany implements RelationAttribute
     public string $morphName;
 
     /**
-     * @var array<mixed>
+     * @var array<string>
      */
     public array $arguments = [];
 
     /**
      * @param  class-string  $relationClass
-     * @param  array<mixed>  ...$arguments
+     * @param  array<string>  ...$arguments
      */
-    public function __construct(string $relationClass, string $morphName, array ...$arguments)
+    public function __construct(string $relationClass, string $morphName, string ...$arguments)
     {
         $this->relationClass = $relationClass;
         $this->morphName = $morphName;
@@ -39,6 +39,6 @@ final class MorphMany implements RelationAttribute
 
     public function relationName(): string
     {
-        return Str::plural(mb_strtolower(class_basename($this->relationClass)));
+        return Str::plural(Str::camel(class_basename($this->relationClass)));
     }
 }

--- a/src/Attributes/Relations/MorphOne.php
+++ b/src/Attributes/Relations/MorphOne.php
@@ -22,7 +22,7 @@ final class MorphOne implements RelationAttribute
     public string $morphName;
 
     /**
-     * @var array<string>
+     * @var array<string|class-string>
      */
     public array $arguments = [];
 

--- a/src/Attributes/Relations/MorphOne.php
+++ b/src/Attributes/Relations/MorphOne.php
@@ -22,15 +22,15 @@ final class MorphOne implements RelationAttribute
     public string $morphName;
 
     /**
-     * @var array<mixed>
+     * @var array<string>
      */
     public array $arguments = [];
 
     /**
      * @param  class-string  $relationClass
-     * @param  array<mixed>  ...$arguments
+     * @param  array<string>  ...$arguments
      */
-    public function __construct(string $relationClass, string $morphName, array ...$arguments)
+    public function __construct(string $relationClass, string $morphName, string ...$arguments)
     {
         $this->relationClass = $relationClass;
         $this->morphName = $morphName;
@@ -39,6 +39,6 @@ final class MorphOne implements RelationAttribute
 
     public function relationName(): string
     {
-        return Str::singular(mb_strtolower(class_basename($this->relationClass)));
+        return Str::singular(Str::camel(class_basename($this->relationClass)));
     }
 }

--- a/src/Attributes/Relations/MorphTo.php
+++ b/src/Attributes/Relations/MorphTo.php
@@ -16,7 +16,7 @@ final class MorphTo implements RelationAttribute
     public string $morphName;
 
     /**
-     * @var array<mixed>
+     * @var array<string|class-string>
      */
     public array $arguments = [];
 

--- a/src/Attributes/Relations/MorphTo.php
+++ b/src/Attributes/Relations/MorphTo.php
@@ -21,9 +21,9 @@ final class MorphTo implements RelationAttribute
     public array $arguments = [];
 
     /**
-     * @param  array<mixed>  ...$arguments
+     * @param  array<string>  ...$arguments
      */
-    public function __construct(string $morphName, array ...$arguments)
+    public function __construct(string $morphName, string ...$arguments)
     {
         $this->morphName = $morphName;
         $this->arguments = [$morphName, ...$arguments];

--- a/src/Attributes/Relations/MorphToMany.php
+++ b/src/Attributes/Relations/MorphToMany.php
@@ -22,15 +22,15 @@ final class MorphToMany implements RelationAttribute
     public string $morphName;
 
     /**
-     * @var array<mixed>
+     * @var array<string>
      */
     public array $arguments = [];
 
     /**
      * @param  class-string  $relationClass
-     * @param  array<mixed>  ...$arguments
+     * @param  array<string>  ...$arguments
      */
-    public function __construct(string $relationClass, string $morphName, array ...$arguments)
+    public function __construct(string $relationClass, string $morphName, string ...$arguments)
     {
         $this->relationClass = $relationClass;
         $this->morphName = $morphName;
@@ -39,6 +39,6 @@ final class MorphToMany implements RelationAttribute
 
     public function relationName(): string
     {
-        return Str::plural(mb_strtolower(class_basename($this->relationClass)));
+        return Str::plural(Str::camel(class_basename($this->relationClass)));
     }
 }

--- a/src/Attributes/Relations/MorphToMany.php
+++ b/src/Attributes/Relations/MorphToMany.php
@@ -22,7 +22,7 @@ final class MorphToMany implements RelationAttribute
     public string $morphName;
 
     /**
-     * @var array<string>
+     * @var array<string|class-string>
      */
     public array $arguments = [];
 

--- a/src/Attributes/Relations/MorphedByMany.php
+++ b/src/Attributes/Relations/MorphedByMany.php
@@ -22,15 +22,15 @@ final class MorphedByMany implements RelationAttribute
     public string $morphName;
 
     /**
-     * @var array<mixed>
+     * @var array<string>
      */
     public array $arguments = [];
 
     /**
      * @param  class-string  $relationClass
-     * @param  array<mixed>  ...$arguments
+     * @param  array<string>  ...$arguments
      */
-    public function __construct(string $relationClass, string $morphName, array ...$arguments)
+    public function __construct(string $relationClass, string $morphName, string ...$arguments)
     {
         $this->relationClass = $relationClass;
         $this->morphName = $morphName;
@@ -39,6 +39,6 @@ final class MorphedByMany implements RelationAttribute
 
     public function relationName(): string
     {
-        return Str::plural(mb_strtolower(class_basename($this->relationClass)));
+        return Str::plural(Str::camel(class_basename($this->relationClass)));
     }
 }

--- a/src/Attributes/Relations/MorphedByMany.php
+++ b/src/Attributes/Relations/MorphedByMany.php
@@ -22,7 +22,7 @@ final class MorphedByMany implements RelationAttribute
     public string $morphName;
 
     /**
-     * @var array<string>
+     * @var array<string|class-string>
      */
     public array $arguments = [];
 

--- a/tests/Datasets/Book.php
+++ b/tests/Datasets/Book.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Tests\Datasets;
+
+use Illuminate\Database\Eloquent\Model;
+use WendellAdriel\Lift\Attributes\PrimaryKey;
+use WendellAdriel\Lift\Attributes\Relations\BelongsTo;
+use WendellAdriel\Lift\Attributes\Relations\HasMany;
+use WendellAdriel\Lift\Attributes\Rules;
+use WendellAdriel\Lift\Lift;
+
+#[BelongsTo(BookCase::class)]
+#[HasMany(Price::class, 'custom_id', 'id')]
+class Book extends Model
+{
+    use Lift;
+
+    #[PrimaryKey]
+    public int $id;
+
+    #[Rules(['required', 'string'], ['required' => 'The book name cannot be empty'])]
+    public string $name;
+
+    protected $fillable = [
+        'name',
+    ];
+}

--- a/tests/Datasets/BookCase.php
+++ b/tests/Datasets/BookCase.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Tests\Datasets;
+
+use Illuminate\Database\Eloquent\Model;
+use WendellAdriel\Lift\Attributes\PrimaryKey;
+use WendellAdriel\Lift\Attributes\Relations\HasMany;
+use WendellAdriel\Lift\Attributes\Rules;
+use WendellAdriel\Lift\Lift;
+
+#[HasMany(Book::class)]
+class BookCase extends Model
+{
+    use Lift;
+
+    #[PrimaryKey]
+    public int $id;
+
+    #[Rules(['required', 'string'], ['required' => 'The book name cannot be empty'])]
+    public string $name;
+
+    protected $fillable = [
+        'name',
+    ];
+}

--- a/tests/Datasets/Price.php
+++ b/tests/Datasets/Price.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Tests\Datasets;
+
+use Illuminate\Database\Eloquent\Model;
+use WendellAdriel\Lift\Attributes\PrimaryKey;
+use WendellAdriel\Lift\Attributes\Relations\BelongsTo;
+use WendellAdriel\Lift\Attributes\Rules;
+use WendellAdriel\Lift\Lift;
+
+#[BelongsTo(Book::class, 'custom_id', 'id')]
+class Price extends Model
+{
+    use Lift;
+
+    #[PrimaryKey]
+    public int $id;
+
+    #[Rules(['required', 'decimal:2'])]
+    public float $price;
+
+    protected $fillable = [
+        'price',
+    ];
+}

--- a/tests/Feature/RelationsTest.php
+++ b/tests/Feature/RelationsTest.php
@@ -2,12 +2,15 @@
 
 declare(strict_types=1);
 
+use WendellAdriel\Lift\Tests\Datasets\Book;
+use WendellAdriel\Lift\Tests\Datasets\BookCase;
 use WendellAdriel\Lift\Tests\Datasets\Computer;
 use WendellAdriel\Lift\Tests\Datasets\Country;
 use WendellAdriel\Lift\Tests\Datasets\Image;
 use WendellAdriel\Lift\Tests\Datasets\Manufacturer;
 use WendellAdriel\Lift\Tests\Datasets\Phone;
 use WendellAdriel\Lift\Tests\Datasets\Post;
+use WendellAdriel\Lift\Tests\Datasets\Price;
 use WendellAdriel\Lift\Tests\Datasets\Role;
 use WendellAdriel\Lift\Tests\Datasets\Seller;
 use WendellAdriel\Lift\Tests\Datasets\Tag;
@@ -247,4 +250,48 @@ it('loads MorphToMany/MorphedByMany relations', function () {
         ->and($post->tags->first()->id)->toBe($tag->id)
         ->and($tag->posts)->toHaveCount(1)
         ->and($tag->posts->first()->id)->toBe($post->id);
+});
+
+it('loads a camelCase relation', function () {
+    $bookCase = BookCase::create([
+        'name' => fake()->name,
+    ]);
+
+    $book = $bookCase->books()->create([
+        'name' => fake()->name,
+    ]);
+
+    expect($bookCase->books)->toHaveCount(1)
+        ->and($bookCase->books->first()->id)->toBe($book->id)
+        ->and($book->bookCase->id)->toBe($bookCase->id)
+        ->and($book->book_case_id)->toBe($bookCase->id);
+
+    $bookCase = BookCase::query()->find($bookCase->id);
+    expect($bookCase->books)->toHaveCount(1)
+        ->and($bookCase->books->first()->id)->toBe($book->id);
+
+    $book = Book::query()->find($book->id);
+    expect($book->bookCase->id)->toBe($bookCase->id);
+});
+
+it('loads a relation with arguments', function () {
+    $book = Book::create([
+        'name' => fake()->name,
+    ]);
+
+    $price = $book->prices()->create([
+        'price' => fake()->randomFloat(2),
+    ]);
+
+    expect($book->prices)->toHaveCount(1)
+        ->and($book->prices->first()->id)->toBe($price->id)
+        ->and($price->book->id)->toBe($book->id)
+        ->and($price->custom_id)->toBe($book->id);
+
+    $book = Book::query()->find($book->id);
+    expect($book->prices)->toHaveCount(1)
+        ->and($book->prices->first()->id)->toBe($price->id);
+
+    $price = Price::query()->find($price->id);
+    expect($price->book->id)->toBe($price->id);
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -121,5 +121,25 @@ abstract class TestCase extends BaseTestCase
             $table->morphs('taggable');
             $table->timestamps();
         });
+
+        Schema::create('book_cases', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('books', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('book_case_id')->nullable()->constrained();
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('prices', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('custom_id')->nullable()->constrained();
+            $table->decimal('price');
+            $table->timestamps();
+        });
     }
 }


### PR DESCRIPTION
The relation attributes weren't accepting arguments, since an array was expected.
Fixes the following syntax: `#[BelongsTo(User::class, 'id', 'custom_id')]`

From the [docs](https://laravel.com/docs/10.x/eloquent-relationships#dynamic-relationships): `When defining dynamic relationships, always provide explicit key name arguments to the Eloquent relationship methods.` Maybe we should add a key to the relation by default?