### PR TITLE
Fix extending models with BelongsTo

### DIFF
--- a/src/Concerns/ManageRelations.php
+++ b/src/Concerns/ManageRelations.php
@@ -22,14 +22,14 @@ trait ManageRelations
     /**
      * @return array<class-string, RelationAttribute>
      */
-    private static function relationsConfig(): array
+    private static function relationsConfig(Model $model): array
     {
         if (is_null(self::$relationsConfig)) {
             self::$relationsConfig = [];
             self::buildRelations(new static());
         }
 
-        return self::$relationsConfig;
+        return self::$relationsConfig[$model::class] ?? [];
     }
 
     private static function buildRelations(Model $model): void
@@ -52,14 +52,14 @@ trait ManageRelations
             );
 
             if ($relation instanceof BelongsTo) {
-                self::$relationsConfig[$relation->relationClass ?? $relation->morphName] = $relation;
+                self::$relationsConfig[$model::class][$relation->relationClass ?? $relation->morphName] = $relation;
             }
         }
     }
 
     private static function handleRelationsKeys(Model $model): void
     {
-        foreach (self::relationsConfig() as $relatedClass => $relationConfig) {
+        foreach (self::relationsConfig($model) as $relatedClass => $relationConfig) {
             $related = new $relatedClass();
 
             $foreignKey = $relationConfig->relationArguments()[1] ?? Str::snake($relationConfig->relationName()) . '_' . $related->getKeyName();

--- a/tests/Datasets/Library.php
+++ b/tests/Datasets/Library.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Tests\Datasets;
+
+use Illuminate\Database\Eloquent\Model;
+use WendellAdriel\Lift\Attributes\PrimaryKey;
+use WendellAdriel\Lift\Attributes\Relations\HasMany;
+use WendellAdriel\Lift\Lift;
+
+#[HasMany(LibraryBook::class)]
+class Library extends Model
+{
+    use Lift;
+
+    #[PrimaryKey]
+    public int $id;
+}

--- a/tests/Datasets/LibraryBook.php
+++ b/tests/Datasets/LibraryBook.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Tests\Datasets;
+
+use WendellAdriel\Lift\Attributes\Relations\BelongsTo;
+
+#[BelongsTo(Library::class)]
+class LibraryBook extends Book
+{
+}

--- a/tests/Datasets/User.php
+++ b/tests/Datasets/User.php
@@ -15,6 +15,7 @@ use WendellAdriel\Lift\Lift;
 
 #[BelongsToMany(Role::class)]
 #[HasMany(Post::class)]
+#[HasMany(WorkBook::class)]
 #[HasOne(Phone::class)]
 #[MorphOne(Image::class, 'imageable')]
 class User extends Model

--- a/tests/Datasets/WorkBook.php
+++ b/tests/Datasets/WorkBook.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Tests\Datasets;
+
+use WendellAdriel\Lift\Attributes\Relations\BelongsTo;
+
+#[BelongsTo(User::class)]
+class WorkBook extends Book
+{
+}

--- a/tests/Feature/RelationsTest.php
+++ b/tests/Feature/RelationsTest.php
@@ -7,6 +7,8 @@ use WendellAdriel\Lift\Tests\Datasets\BookCase;
 use WendellAdriel\Lift\Tests\Datasets\Computer;
 use WendellAdriel\Lift\Tests\Datasets\Country;
 use WendellAdriel\Lift\Tests\Datasets\Image;
+use WendellAdriel\Lift\Tests\Datasets\Library;
+use WendellAdriel\Lift\Tests\Datasets\LibraryBook;
 use WendellAdriel\Lift\Tests\Datasets\Manufacturer;
 use WendellAdriel\Lift\Tests\Datasets\Phone;
 use WendellAdriel\Lift\Tests\Datasets\Post;
@@ -14,6 +16,7 @@ use WendellAdriel\Lift\Tests\Datasets\Role;
 use WendellAdriel\Lift\Tests\Datasets\Seller;
 use WendellAdriel\Lift\Tests\Datasets\Tag;
 use WendellAdriel\Lift\Tests\Datasets\User;
+use WendellAdriel\Lift\Tests\Datasets\WorkBook;
 
 it('loads BelongsTo relation', function () {
     $user = User::create([
@@ -271,4 +274,24 @@ it('loads a camelCase relation', function () {
 
     $book = Book::query()->find($book->id);
     expect($book->bookCase->id)->toBe($bookCase->id);
+});
+
+it('will not add unnecessary keys', function () {
+    User::create([
+        'name' => fake()->name,
+        'email' => fake()->unique()->safeEmail,
+        'password' => 's3Cr3T@!!!',
+    ])->workBooks()->create([
+        'name' => fake()->name,
+    ]);
+
+    Library::create()->libraryBooks()->create([
+        'name' => fake()->name,
+    ]);
+
+    $workBook = WorkBook::query()->first();
+    $libraryBook = LibraryBook::query()->first();
+
+    expect($workBook->save())->toBeTrue()
+        ->and($libraryBook->save())->toBeTrue();
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -134,5 +134,26 @@ abstract class TestCase extends BaseTestCase
             $table->string('name');
             $table->timestamps();
         });
+
+        Schema::create('libraries', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+
+        Schema::create('library_books', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('library_id')->nullable()->constrained();
+            $table->foreignId('book_case_id')->nullable()->constrained();
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('work_books', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->nullable()->constrained();
+            $table->foreignId('book_case_id')->nullable()->constrained();
+            $table->string('name');
+            $table->timestamps();
+        });
     }
 }


### PR DESCRIPTION
In the current situation, when a parent class that uses `Lift` is being extended and the child classes use `#[BelongsTo]`, the `#[BelongsTo]` relation will be added to both children. This causes errors while saving the model, because `Lift` is trying to set unknown columns (e.g. it tries to set `user_id` to `LibraryBook`, while only `WorkBook` belongs to a `User`).