### PR TITLE
Fix behaviour for toArray and toJson methods

### DIFF
--- a/src/Lift.php
+++ b/src/Lift.php
@@ -99,6 +99,19 @@ trait Lift
         $this->applyAttributesGuard($properties);
     }
 
+    public function toArray(): array
+    {
+        $array = parent::toArray();
+        $customColumns = array_flip(self::customColumns());
+        $result = [];
+
+        foreach ($array as $key => $value) {
+            $result[$customColumns[$key] ?? $key] = $value;
+        }
+
+        return $result;
+    }
+
     protected static function ignoredProperties(): array
     {
         return [

--- a/tests/Feature/ColumnTest.php
+++ b/tests/Feature/ColumnTest.php
@@ -18,6 +18,33 @@ it('returns model default values', function () {
     ]);
 });
 
+it('returns array with model properties when custom columns are defined', function () {
+    $user = UserColumn::create([
+        'name' => fake()->name,
+        'user_email' => fake()->unique()->safeEmail,
+        'user_password' => 's3Cr3T@!!!',
+    ]);
+
+    expect($user->toArray())->toHaveKeys([
+        'id',
+        'name',
+        'user_email',
+        'user_password',
+        'created_at',
+        'updated_at',
+    ]);
+});
+
+it('returns json with model properties when custom columns are defined', function () {
+    $user = UserColumn::create([
+        'name' => fake()->name,
+        'user_email' => fake()->unique()->safeEmail,
+        'user_password' => 's3Cr3T@!!!',
+    ]);
+
+    expect($user->toJson())->toBe(json_encode($user->toArray()));
+});
+
 describe('creates new model with custom columns', function () {
     it('creates model with individual properties set', function () {
         $user = new UserColumn();


### PR DESCRIPTION
This PR fixes the issue that currently when you set a custom column name to a model, when converting it to array or json the array/json uses the DB columns names instead of the properties defined in the Model. With this PR, even when a field has a custom column name set, the array/json will use the model property name instead.