### PR TITLE
Add lift:migration command

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,5 +11,5 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
-[*.{yml,yaml,json}]
+[*.{yml,yaml}]
 indent_size = 2

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
     <a href="#installation">Installation</a> |
     <a href="#attributes">Attributes</a> |
     <a href="#method">Methods</a> |
+    <a href="#commands">Commands</a> |
     <a href="#credits">Credits</a> |
     <a href="#contributing">Contributing</a>
 </p>
@@ -794,6 +795,37 @@ $productWatchedProperties = Product::watchedProperties();
 [
     'price' => PriceChangedEvent::class,
 ]
+```
+
+## Commands
+
+### lift:migration
+
+> ⚠️ **This is an experimental feature still, and currently it allows to generate only create table statements**
+
+The `lift:migration` command allows you to generate a migration file based on your models. By default it uses the `App\Models`
+namespace, but you can change it using the `--namespace` option.
+
+All the created migration files will be placed inside the `database/migrations` folder.
+
+**Examples:**
+
+The command below will generate a migration file for the `App\Models\User` model.
+
+```bash
+php artisan lift:migration User
+```
+
+The command below will generate a migration file for the `App\Models\Auth\User` model.
+
+```bash
+php artisan lift:migration Auth\User
+```
+
+The command below will generate a migration file for the `App\Custom\Models\User` model.
+
+```bash
+php artisan lift:migration User --namespace=App\Custom\Models
 ```
 
 ## Credits

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,13 @@
             "@test:static"
         ]
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "WendellAdriel\\Lift\\Providers\\LiftServiceProvider"
+            ]
+        }
+    },
     "config": {
         "allow-plugins": {
             "pestphp/pest-plugin": true

--- a/src/Console/Commands/LiftMigration.php
+++ b/src/Console/Commands/LiftMigration.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Console\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionProperty;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Throwable;
+use WendellAdriel\Lift\Lift;
+
+#[AsCommand(name: 'lift:migration', description: 'Create migration files based on Lift models')]
+final class LiftMigration extends Command
+{
+    protected $name = 'lift:migration';
+
+    protected $signature = 'lift:migration {model}
+                            {--namespace=App\\Models\\}';
+
+    protected static $defaultName = 'lift:migration';
+
+    protected $description = 'Create migration files based on Lift models';
+
+    public function handle(): int
+    {
+        try {
+            $class = $this->option('namespace') . '\\' . $this->argument('model'); // @phpstan-ignore-line
+
+            if (! class_exists($class)) {
+                $this->error("Model {$class} not found.");
+
+                return Command::FAILURE;
+            }
+
+            if (! in_array(Lift::class, class_uses($class))) {
+                $this->error("Model {$class} does not use Lift trait.");
+
+                return Command::FAILURE;
+            }
+
+            /** @var Model $model */
+            $model = new $class();
+            $table = $model->getTable();
+
+            $this->info("Generating migration file for model {$class} (table {$table})");
+            $modelProperties = $this->buildModelPropertiesList($class);
+            $migrationCalls = $this->buildMigrationCalls($model, $modelProperties);
+
+            $migrationPath = $this->generateMigrationFile($table, $migrationCalls);
+            $this->info("Migration file generated at {$migrationPath}.");
+
+            return Command::SUCCESS;
+        } catch (Throwable $exception) {
+            $this->error("Something went wrong while generating the migration file: {$exception->getMessage()}");
+
+            return Command::FAILURE;
+        }
+    }
+
+    /**
+     * @param  class-string  $class
+     * @return array<string, ReflectionNamedType|null>
+     */
+    private function buildModelPropertiesList(string $class): array
+    {
+        $reflectionClass = new ReflectionClass($class);
+        $properties = $reflectionClass->getProperties(ReflectionProperty::IS_PUBLIC);
+        $ignoredProperties = $class::ignoredProperties();
+        $result = [];
+
+        foreach ($properties as $property) {
+            $propertyName = $property->getName();
+            if (in_array($propertyName, $ignoredProperties)) {
+                continue;
+            }
+
+            /** @var ReflectionNamedType|null $type */
+            $type = $property->getType() ?? null;
+            $result[$propertyName] = $type;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  array<string, ReflectionNamedType|null>  $modelProperties
+     * @return array<string>
+     */
+    private function buildMigrationCalls(Model $model, array $modelProperties): array
+    {
+        $result = [];
+
+        foreach ($modelProperties as $property => $type) {
+            if ($property === $model->getKeyName()) {
+                $result[] = $this->buildPrimaryKeyMigrationCall($property, $type);
+
+                continue;
+            }
+
+            if (blank($type)) {
+                $result[] = "\$table->string('{$property}');";
+
+                continue;
+            }
+
+            $result[] = match (true) {
+                $this->isDateType($type) => $this->generateMigrationCall('timestamp', $type, $property), // @phpstan-ignore-line
+                $type->getName() === 'bool' => $this->generateMigrationCall('boolean', $type, $property), // @phpstan-ignore-line
+                $type->getName() === 'int' => $this->generateMigrationCall('integer', $type, $property), // @phpstan-ignore-line
+                $type->getName() === 'float' => $this->generateMigrationCall('float', $type, $property), // @phpstan-ignore-line
+                $type->getName() === 'string' => $this->generateMigrationCall('string', $type, $property), // @phpstan-ignore-line
+                $type->getName() === 'array' => $this->generateMigrationCall('json', $type, $property), // @phpstan-ignore-line
+                $type->getName() === 'object' => $this->generateMigrationCall('json', $type, $property), // @phpstan-ignore-line
+                default => $this->generateMigrationCall('string', $type, $property), // @phpstan-ignore-line
+            };
+        }
+
+        if ($model->usesTimestamps()) {
+            $result[] = '$table->timestamps();';
+        }
+
+        if (in_array(SoftDeletes::class, class_uses($model))) {
+            $result[] = '$table->softDeletes();';
+        }
+
+        return $result;
+    }
+
+    private function buildPrimaryKeyMigrationCall(string $property, ?ReflectionNamedType $type): string
+    {
+        return ! blank($type) && $type->getName() === 'int' // @phpstan-ignore-line
+            ? '$table->id();'
+            : "\$table->string('{$property}')->primary();";
+    }
+
+    private function isDateType(ReflectionNamedType $type): bool
+    {
+        return in_array($type->getName(), ['Carbon\Carbon', 'Carbon\CarbonImmutable', 'DateTime']);
+    }
+
+    private function generateMigrationCall(string $method, ReflectionNamedType $type, string $property): string
+    {
+        $result = "\$table->{$method}('{$property}')";
+        if ($type->allowsNull()) {
+            $result .= '->nullable()';
+        }
+
+        return "{$result};";
+    }
+
+    /**
+     * @param  array<string>  $migrationCalls
+     */
+    private function generateMigrationFile(string $table, array $migrationCalls): string
+    {
+        $stub = $this->getStub();
+        $migrationCalls = implode("\n            ", $migrationCalls);
+        $migrationContent = str_replace(['{{TABLE_NAME}}', '{{FIELDS_LIST}}'], [$table, $migrationCalls], $stub);
+        $migrationPath = $this->buildMigrationFilePath($table);
+        file_put_contents($migrationPath, $migrationContent);
+
+        return $migrationPath;
+    }
+
+    private function getStub(): string
+    {
+        return (string) file_get_contents(__DIR__ . '/../stubs/MigrationCreate.stub');
+    }
+
+    private function buildMigrationFilePath(string $table): string
+    {
+        $timestamp = Carbon::now()->format('Y_m_d_His');
+
+        return $this->laravel->databasePath("migrations/{$timestamp}_create_{$table}_table.php");
+    }
+}

--- a/src/Console/stubs/MigrationCreate.stub
+++ b/src/Console/stubs/MigrationCreate.stub
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('{{TABLE_NAME}}', function (Blueprint $table) {
+            {{FIELDS_LIST}}
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('{{TABLE_NAME}}');
+    }
+};

--- a/src/Providers/LiftServiceProvider.php
+++ b/src/Providers/LiftServiceProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use WendellAdriel\Lift\Console\Commands\LiftMigration;
+
+final class LiftServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->commands(LiftMigration::class);
+        }
+    }
+}

--- a/tests/Datasets/UserMigration.php
+++ b/tests/Datasets/UserMigration.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Tests\Datasets;
+
+use Carbon\CarbonImmutable;
+use DateTime;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use WendellAdriel\Lift\Attributes\DB;
+use WendellAdriel\Lift\Attributes\PrimaryKey;
+use WendellAdriel\Lift\Attributes\Rules;
+use WendellAdriel\Lift\Lift;
+
+#[DB(table: 'users_migration')]
+final class UserMigration extends Model
+{
+    use Lift, SoftDeletes;
+
+    #[PrimaryKey]
+    public int $id;
+
+    #[Rules(['required', 'string'], ['required' => 'The user name cannot be empty'])]
+    public string $name;
+
+    #[Rules(['required', 'email'])]
+    public string $email;
+
+    #[Rules(['required', 'string', 'min:8'])]
+    public string $password;
+
+    public CarbonImmutable $created_at;
+
+    public DateTime $updated_at;
+
+    public ?bool $active;
+
+    public $test;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+}

--- a/tests/Feature/LiftMigrationTest.php
+++ b/tests/Feature/LiftMigrationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+it('generates a migration file for a model', function () {
+    $migrationClass = database_path('migrations/' . date('Y_m_d_His') . '_create_users_migration_table.php');
+
+    $this->artisan('lift:migration UserMigration --namespace=WendellAdriel\\\Lift\\\Tests\\\Datasets')
+        ->assertExitCode(0);
+
+    expect($migrationClass)->toBeFileWithContent(UserMigration());
+
+    unlink($migrationClass);
+});
+
+function UserMigration(): string
+{
+    return <<<'CLASS'
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users_migration', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email');
+            $table->string('password');
+            $table->timestamp('created_at');
+            $table->timestamp('updated_at');
+            $table->boolean('active')->nullable();
+            $table->string('test');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('users_migration');
+    }
+};
+
+CLASS;
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -29,7 +29,13 @@ uses(
 |
 */
 
-expect()->extend('toBeOne', fn () => $this->toBe(1));
+expect()->extend('toBeFileWithContent', function (string $fileContent) {
+    test()->assertFileExists($this->value);
+
+    expect(file_get_contents($this->value))->toBe($fileContent);
+
+    return $this;
+});
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -168,4 +168,9 @@ abstract class TestCase extends BaseTestCase
             $table->timestamps();
         });
     }
+
+    protected function getPackageProviders($app)
+    {
+        return ['WendellAdriel\Lift\Providers\LiftServiceProvider'];
+    }
 }


### PR DESCRIPTION
This PR adds a `lift:migration` command to create migrations from the Models' definition.