### PR TITLE
Lift migration update table

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,7 +801,7 @@ $productWatchedProperties = Product::watchedProperties();
 
 ### lift:migration
 
-> ⚠️ **This is an experimental feature still, and currently it allows to generate only create table statements**
+> ⚠️ **This is an experimental feature, keep that in mind when using it**
 
 The `lift:migration` command allows you to generate a migration file based on your models. By default it uses the `App\Models`
 namespace, but you can change it using the `--namespace` option.
@@ -826,6 +826,128 @@ The command below will generate a migration file for the `App\Custom\Models\User
 
 ```bash
 php artisan lift:migration User --namespace=App\Custom\Models
+```
+
+#### Create Table Migration
+
+When the table for your model is not yet created in the database, the `lift:migration` command will generate a migration
+file to create the table.
+
+```php
+// User.php
+
+final class User extends Model
+{
+    use Lift, SoftDeletes;
+
+    public int $id;
+
+    public string $name;
+
+    public string $email;
+
+    public string $password;
+
+    public CarbonImmutable $created_at;
+
+    public DateTime $updated_at;
+
+    public ?bool $active;
+
+    public $test;
+}
+
+// Migration file generated
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email');
+            $table->string('password');
+            $table->boolean('active')->nullable();
+            $table->string('test');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+};
+```
+
+#### Update Table Migration
+
+When the table for your model is already created in the database, the `lift:migration` command will generate a migration
+file to update the table based in the differences between the model and the database table.
+
+```php
+// User.php
+
+final class User extends Model
+{
+    use Lift, SoftDeletes;
+
+    public int $id;
+
+    public string $name;
+
+    public string $username;
+
+    public string $email;
+
+    public string $password;
+
+    public ?bool $active;
+}
+
+// Migration file generated
+
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users_migrated', function (Blueprint $table) {
+            $table->string('username')->after('name');
+            $table->dropColumn('created_at');
+            $table->dropColumn('updated_at');
+            $table->dropColumn('test');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Nothing to do here
+    }
+};
 ```
 
 ## Credits

--- a/src/Console/stubs/MigrationUpdate.stub
+++ b/src/Console/stubs/MigrationUpdate.stub
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('{{TABLE_NAME}}', function (Blueprint $table) {
+            {{FIELDS_LIST}}
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Nothing to do here
+    }
+};

--- a/tests/Datasets/UserMigratedUpdateTable.php
+++ b/tests/Datasets/UserMigratedUpdateTable.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use WendellAdriel\Lift\Attributes\DB;
+use WendellAdriel\Lift\Attributes\PrimaryKey;
+use WendellAdriel\Lift\Attributes\Rules;
+use WendellAdriel\Lift\Lift;
+
+#[DB(table: 'users_migrated')]
+final class UserMigratedUpdateTable extends Model
+{
+    use Lift, SoftDeletes;
+
+    #[PrimaryKey]
+    public int $id;
+
+    #[Rules(['required', 'string'], ['required' => 'The user name cannot be empty'])]
+    public string $name;
+
+    public string $username;
+
+    #[Rules(['required', 'email'])]
+    public string $email;
+
+    #[Rules(['required', 'string', 'min:8'])]
+    public string $password;
+
+    public ?bool $active;
+}

--- a/tests/Feature/LiftMigrationTest.php
+++ b/tests/Feature/LiftMigrationTest.php
@@ -2,18 +2,33 @@
 
 declare(strict_types=1);
 
-it('generates a migration file for a model', function () {
-    $migrationClass = database_path('migrations/' . date('Y_m_d_His') . '_create_users_migration_table.php');
+describe('CREATE TABLE', function () {
+    it('generates a migration file for a model', function () {
+        $migrationClass = database_path('migrations/' . date('Y_m_d_His') . '_create_users_migration_table.php');
 
-    $this->artisan('lift:migration UserMigration --namespace=Tests\\\Datasets')
-        ->assertExitCode(0);
+        $this->artisan('lift:migration UserMigration --namespace=Tests\\\Datasets')
+            ->assertExitCode(0);
 
-    expect($migrationClass)->toBeFileWithContent(UserMigration());
+        expect($migrationClass)->toBeFileWithContent(UserMigrationCreate());
 
-    unlink($migrationClass);
+        unlink($migrationClass);
+    });
 });
 
-function UserMigration(): string
+describe('UPDATE TABLE', function () {
+    it('generates a migration file for a model adding and droping columns', function () {
+        $migrationClass = database_path('migrations/' . date('Y_m_d_His') . '_update_users_migrated_table.php');
+
+        $this->artisan('lift:migration UserMigratedUpdateTable --namespace=Tests\\\Datasets')
+            ->assertExitCode(0);
+
+        expect($migrationClass)->toBeFileWithContent(UserMigrationAddColumns());
+
+        unlink($migrationClass);
+    });
+});
+
+function UserMigrationCreate(): string
 {
     return <<<'CLASS'
 <?php
@@ -47,6 +62,43 @@ return new class extends Migration
     public function down(): void
     {
         Schema::dropIfExists('users_migration');
+    }
+};
+
+CLASS;
+}
+
+function UserMigrationAddColumns(): string
+{
+    return <<<'CLASS'
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users_migrated', function (Blueprint $table) {
+            $table->string('username')->after('name');
+            $table->boolean('active')->nullable()->after('password');
+            $table->softDeletes();
+            $table->dropColumn('created_at');
+            $table->dropColumn('updated_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Nothing to do here
     }
 };
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -167,6 +167,14 @@ abstract class TestCase extends BaseTestCase
             $table->string('movie_id')->primary();
             $table->timestamps();
         });
+
+        Schema::create('users_migrated', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email');
+            $table->string('password');
+            $table->timestamps();
+        });
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
This PR updates the `lift:migration` command to be able to generate update migrations based on the differences between the model and the database table