### PR TITLE
Create ide.json

### DIFF
--- a/ide.json
+++ b/ide.json
@@ -13,6 +13,16 @@
                     "newClassFqn": ["WendellAdriel\\Lift\\Attributes\\Rules", "WendellAdriel\\Lift\\Attributes\\CreateRules", "WendellAdriel\\Lift\\Attributes\\UpdateRules"],
                     "parameters": [2],
                     "place": "arrayKey"
+                },
+                {
+                    "newClassFqn": ["WendellAdriel\\Lift\\Attributes\\Config"],
+                    "parameterNames": ["rules"],
+                    "place": "arrayValue"
+                },
+                {
+                    "newClassFqn": ["WendellAdriel\\Lift\\Attributes\\Config"],
+                    "parameterNames": ["messages"],
+                    "place": "arrayKey"
                 }
             ]
         },
@@ -21,6 +31,11 @@
             "condition": [
                 {
                     "newClassFqn": ["WendellAdriel\\Lift\\Attributes\\Cast"],
+                    "parameters": [1]
+                },
+                {
+                    "newClassFqn": ["WendellAdriel\\Lift\\Attributes\\Config"],
+                    "parameterNames": ["cast"],
                     "parameters": [1]
                 }
             ]

--- a/ide.json
+++ b/ide.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "https://laravel-ide.com/schema/laravel-ide-v2.json",
+    "completions": [
+        {
+            "complete": "validationRule",
+            "condition": [
+                {
+                    "newClassFqn": ["WendellAdriel\\Lift\\Attributes\\Rules", "WendellAdriel\\Lift\\Attributes\\CreateRules", "WendellAdriel\\Lift\\Attributes\\UpdateRules"],
+                    "parameters": [1],
+                    "place": "arrayValue"
+                },
+                {
+                    "newClassFqn": ["WendellAdriel\\Lift\\Attributes\\Rules", "WendellAdriel\\Lift\\Attributes\\CreateRules", "WendellAdriel\\Lift\\Attributes\\UpdateRules"],
+                    "parameters": [2],
+                    "place": "arrayKey"
+                }
+            ]
+        },
+        {
+            "complete": "eloquentCasts",
+            "condition": [
+                {
+                    "newClassFqn": ["WendellAdriel\\Lift\\Attributes\\Cast"],
+                    "parameters": [1]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
add validation rules and Eloquent casts completion for IDE. Currently works only with PhpStorm + Laravel Idea.

"eloquentCasts" will be supported in the next Laravel Idea version.

<img width="330" alt="image" src="https://github.com/WendellAdriel/laravel-lift/assets/2818394/f9279a5a-2113-4f5b-8075-964cf5cd9e85">
