### PR TITLE
Merge hidden attribute list instead of replacing it (same way it is done with fillable etc.)

### DIFF
--- a/src/Concerns/AttributesGuard.php
+++ b/src/Concerns/AttributesGuard.php
@@ -58,11 +58,11 @@ trait AttributesGuard
         $this->mergeFillable($fillableProperties->map(fn ($property) => $property->name)->values()->toArray());
 
         $hiddenProperties = self::getPropertiesForAttributes($properties, [Hidden::class]);
-        $this->setHidden($hiddenProperties->map(fn ($property) => $property->name)->values()->toArray());
+        $this->makeHidden($hiddenProperties->map(fn ($property) => $property->name)->values()->toArray());
 
         $configProperties = self::getPropertiesForAttributes($properties, [Config::class]);
         $this->mergeFillable($this->buildLiftList($configProperties, 'fillable'));
-        $this->setHidden([
+        $this->makeHidden([
             ...$this->getHidden(),
             ...$this->buildLiftList($configProperties, 'hidden'),
         ]);

--- a/tests/Datasets/ProductHidden.php
+++ b/tests/Datasets/ProductHidden.php
@@ -25,13 +25,21 @@ class ProductHidden extends Model
     #[Cast('int')]
     public int $random_number;
 
+    #[Cast('int')]
+    public int $another_random_number;
+
     #[Cast('immutable_datetime')]
     public CarbonImmutable $expires_at;
+
+    protected $hidden = [
+        'another_random_number',
+    ];
 
     protected $fillable = [
         'name',
         'price',
         'random_number',
+        'another_random_number',
         'expires_at',
     ];
 }

--- a/tests/Feature/HiddenTest.php
+++ b/tests/Feature/HiddenTest.php
@@ -9,6 +9,7 @@ it('set properties to hidden', function () {
         'name' => 'Product 1',
         'price' => '10.99',
         'random_number' => '123',
+        'another_random_number' => '123',
         'expires_at' => '2023-12-31 23:59:59',
     ]);
 
@@ -17,5 +18,6 @@ it('set properties to hidden', function () {
         ->and($product->random_number)->toBe(123)
         ->and($product->expires_at)->toBeInstanceOf(Carbon\CarbonImmutable::class)
         ->and($product->expires_at->format('Y-m-d H:i:s'))->toBe('2023-12-31 23:59:59')
-        ->and($product->toArray())->not->toHaveKey('random_number');
+        ->and($product->toArray())->not->toHaveKey('random_number')
+        ->and($product->toArray())->not->toHaveKey('another_random_number');
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -53,6 +53,7 @@ abstract class TestCase extends BaseTestCase
             $table->string('name');
             $table->float('price');
             $table->integer('random_number');
+            $table->integer('another_random_number')->nullable();
             $table->timestamp('expires_at');
             $table->timestamps();
         });


### PR DESCRIPTION
In current version of Lift `protected $hidden = ['attribute']` attributes are ignored/replaced by those generated by Lift. I propose merging the hidden attributes as it is done with $fillable just a few lines over.