### PR TITLE
Add cast helper methods

### DIFF
--- a/src/Lift.php
+++ b/src/Lift.php
@@ -54,7 +54,7 @@ trait Lift
                 ? self::applyCreateValidations($properties)
                 : self::applyUpdateValidations($properties);
 
-            self::castValues($model, $properties);
+            self::castValues($model);
 
             $publicProperties = self::getModelPublicProperties($model);
             $customColumns = self::customColumns();
@@ -102,6 +102,7 @@ trait Lift
         $properties = self::getPropertiesWithAttributes($this);
         $this->applyPrimaryKey($properties);
         $this->applyAttributesGuard($properties);
+        self::castValues($this);
     }
 
     public function toArray(): array
@@ -208,7 +209,7 @@ trait Lift
 
     private static function fillProperties(Model $model): void
     {
-        self::castValues($model, self::getPropertiesWithAttributes($model));
+        self::castValues($model);
 
         foreach ($model->getAttributes() as $key => $value) {
             $model->{$key} = $model->hasCast($key) ? $model->castAttribute($key, $value) : $value;

--- a/tests/Datasets/Product.php
+++ b/tests/Datasets/Product.php
@@ -25,7 +25,7 @@ class Product extends Model
     public CarbonImmutable $expires_at;
 
     #[Cast('array')]
-    public array $json_column;
+    public ?array $json_column;
 
     protected $fillable = [
         'name',

--- a/tests/Datasets/ProductConfig.php
+++ b/tests/Datasets/ProductConfig.php
@@ -24,6 +24,6 @@ class ProductConfig extends Model
     #[Config(fillable: true, cast: 'int', hidden: true, rules: ['required', 'integer'])]
     public int $random_number;
 
-    #[Config(fillable: true, cast: 'immutable_datetime', rules: ['required', 'date_format:Y-m-d H:i:s'])]
+    #[Config(fillable: true, cast: 'immutable_datetime', rules: ['required', 'date'])]
     public CarbonImmutable $expires_at;
 }

--- a/tests/Feature/CastTest.php
+++ b/tests/Feature/CastTest.php
@@ -5,14 +5,13 @@ declare(strict_types=1);
 use Tests\Datasets\Product;
 
 it('casts values when creating model', function () {
-    $product = Product::create([
+    $product = Product::castAndCreate([
         'name' => 'Product 1',
         'price' => '10.99',
         'random_number' => '123',
         'expires_at' => '2023-12-31 23:59:59',
-        'json_column' => '["foo": "bar"]',
+        'json_column' => ['foo' => 'bar'],
     ]);
-    $product = $product->fresh();
 
     expect($product->name)->toBe('Product 1')
         ->and($product->price)->toBe(10.99)
@@ -20,26 +19,31 @@ it('casts values when creating model', function () {
         ->and($product->expires_at)->toBeInstanceOf(Carbon\CarbonImmutable::class)
         ->and($product->expires_at->format('Y-m-d H:i:s'))->toBe('2023-12-31 23:59:59')
         ->and($product->json_column)->toBe(['foo' => 'bar']);
+
+    $this->assertDatabaseHas(Product::class, [
+        'name' => 'Product 1',
+        'price' => 10.99,
+        'random_number' => 123,
+        'expires_at' => '2023-12-31 23:59:59',
+        'json_column' => '{"foo":"bar"}',
+    ]);
 });
 
-it('casts values when updating model', function () {
-    $product = Product::create([
+it('casts values when updating model with updateAndCast', function () {
+    $product = Product::castAndCreate([
         'name' => 'Product 1',
         'price' => '10.99',
         'random_number' => '123',
         'expires_at' => '2023-12-31 23:59:59',
     ]);
 
-    $product->update([
+    $product->castAndUpdate([
         'name' => 'Product 2',
         'price' => '20.99',
         'random_number' => '456',
         'expires_at' => '2024-12-31 23:59:59',
+        'json_column' => ['foo' => 'bar'],
     ]);
-
-    $product->json_column = '["foo": "bar"]';
-    $product->save();
-    $product = $product->fresh();
 
     expect($product->name)->toBe('Product 2')
         ->and($product->price)->toBe(20.99)
@@ -47,15 +51,83 @@ it('casts values when updating model', function () {
         ->and($product->expires_at)->toBeInstanceOf(Carbon\CarbonImmutable::class)
         ->and($product->expires_at->format('Y-m-d H:i:s'))->toBe('2024-12-31 23:59:59')
         ->and($product->json_column)->toBe(['foo' => 'bar']);
+
+    $this->assertDatabaseHas(Product::class, [
+        'name' => 'Product 2',
+        'price' => 20.99,
+        'random_number' => 456,
+        'expires_at' => '2024-12-31 23:59:59',
+        'json_column' => '{"foo":"bar"}',
+    ]);
 });
 
-it('casts values when retrieving model', function () {
-    Product::create([
+it('casts value when updating model with fillAndCast', function () {
+    $product = Product::castAndCreate([
         'name' => 'Product 1',
         'price' => '10.99',
         'random_number' => '123',
         'expires_at' => '2023-12-31 23:59:59',
-        'json_column' => '["foo": "bar"]',
+    ]);
+
+    $product->castAndFill([
+        'name' => 'Product 2',
+        'price' => '20.99',
+        'random_number' => '456',
+        'expires_at' => '2024-12-31 23:59:59',
+        'json_column' => '{"foo":"bar"}',
+    ]);
+    $product->save();
+
+    expect($product->name)->toBe('Product 2')
+        ->and($product->price)->toBe(20.99)
+        ->and($product->random_number)->toBe(456)
+        ->and($product->expires_at)->toBeInstanceOf(Carbon\CarbonImmutable::class)
+        ->and($product->expires_at->format('Y-m-d H:i:s'))->toBe('2024-12-31 23:59:59')
+        ->and($product->json_column)->toBe(['foo' => 'bar']);
+
+    $this->assertDatabaseHas(Product::class, [
+        'name' => 'Product 2',
+        'price' => 20.99,
+        'random_number' => 456,
+        'expires_at' => '2024-12-31 23:59:59',
+        'json_column' => '{"foo":"bar"}',
+    ]);
+});
+
+it('casts value when updating model with setAndCast', function () {
+    $product = Product::castAndCreate([
+        'name' => 'Product 1',
+        'price' => '10.99',
+        'random_number' => '123',
+        'expires_at' => '2023-12-31 23:59:59',
+    ]);
+
+    $product->castAndSet('json_column', '{"foo": "bar"}');
+    $product->save();
+
+    expect($product->name)->toBe('Product 1')
+        ->and($product->price)->toBe(10.99)
+        ->and($product->random_number)->toBe(123)
+        ->and($product->expires_at)->toBeInstanceOf(Carbon\CarbonImmutable::class)
+        ->and($product->expires_at->format('Y-m-d H:i:s'))->toBe('2023-12-31 23:59:59')
+        ->and($product->json_column)->toBe(['foo' => 'bar']);
+
+    $this->assertDatabaseHas(Product::class, [
+        'name' => 'Product 1',
+        'price' => 10.99,
+        'random_number' => 123,
+        'expires_at' => '2023-12-31 23:59:59',
+        'json_column' => '{"foo":"bar"}',
+    ]);
+});
+
+it('casts values when retrieving model', function () {
+    Product::castAndCreate([
+        'name' => 'Product 1',
+        'price' => '10.99',
+        'random_number' => '123',
+        'expires_at' => '2023-12-31 23:59:59',
+        'json_column' => '{"foo": "bar"}',
     ]);
     $product = Product::query()->first();
 

--- a/tests/Feature/CastTest.php
+++ b/tests/Feature/CastTest.php
@@ -10,8 +10,9 @@ it('casts values when creating model', function () {
         'price' => '10.99',
         'random_number' => '123',
         'expires_at' => '2023-12-31 23:59:59',
-        'json_column' => ['foo' => 'bar'],
+        'json_column' => '["foo": "bar"]',
     ]);
+    $product = $product->fresh();
 
     expect($product->name)->toBe('Product 1')
         ->and($product->price)->toBe(10.99)
@@ -36,11 +37,16 @@ it('casts values when updating model', function () {
         'expires_at' => '2024-12-31 23:59:59',
     ]);
 
+    $product->json_column = '["foo": "bar"]';
+    $product->save();
+    $product = $product->fresh();
+
     expect($product->name)->toBe('Product 2')
         ->and($product->price)->toBe(20.99)
         ->and($product->random_number)->toBe(456)
         ->and($product->expires_at)->toBeInstanceOf(Carbon\CarbonImmutable::class)
-        ->and($product->expires_at->format('Y-m-d H:i:s'))->toBe('2024-12-31 23:59:59');
+        ->and($product->expires_at->format('Y-m-d H:i:s'))->toBe('2024-12-31 23:59:59')
+        ->and($product->json_column)->toBe(['foo' => 'bar']);
 });
 
 it('casts values when retrieving model', function () {
@@ -49,6 +55,7 @@ it('casts values when retrieving model', function () {
         'price' => '10.99',
         'random_number' => '123',
         'expires_at' => '2023-12-31 23:59:59',
+        'json_column' => '["foo": "bar"]',
     ]);
     $product = Product::query()->first();
 
@@ -56,5 +63,6 @@ it('casts values when retrieving model', function () {
         ->and($product->price)->toBe(10.99)
         ->and($product->random_number)->toBe(123)
         ->and($product->expires_at)->toBeInstanceOf(Carbon\CarbonImmutable::class)
-        ->and($product->expires_at->format('Y-m-d H:i:s'))->toBe('2023-12-31 23:59:59');
+        ->and($product->expires_at->format('Y-m-d H:i:s'))->toBe('2023-12-31 23:59:59')
+        ->and($product->json_column)->toBe(['foo' => 'bar']);
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -53,8 +53,8 @@ abstract class TestCase extends BaseTestCase
             $table->string('name');
             $table->float('price');
             $table->integer('random_number');
-            $table->integer('another_random_number')->nullable();  
-            $table->json('json_column');
+            $table->integer('another_random_number')->nullable();
+            $table->json('json_column')->nullable();
             $table->timestamp('expires_at');
             $table->timestamps();
         });


### PR DESCRIPTION
As discussed in #45 
There are some issues with casting the explicitly declared public properties in the Lift Models.

Some workaround options were discussed:

1 - Updating all properties to be Value Objects

2 - Creating helper methods for casting the attributes when setting them

Option 1 had more issues since it would add complexity and lose the property typing, so this PR implements the 2nd option by creating new helper methods described here: https://github.com/WendellAdriel/laravel-lift-docs/pull/1