### PR TITLE
Add Eloquent Model Event Handling Attributes e.g. #[Created]

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,4 @@ parameters:
 
     excludePaths:
         - src/Support/PropertyInfo.php
+        - src/Support/MethodInfo.php

--- a/src/Attributes/Events/Created.php
+++ b/src/Attributes/Events/Created.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Attributes\Events;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Created
+{
+}

--- a/src/Attributes/Events/Creating.php
+++ b/src/Attributes/Events/Creating.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Attributes\Events;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Creating
+{
+}

--- a/src/Attributes/Events/Deleted.php
+++ b/src/Attributes/Events/Deleted.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Attributes\Events;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Deleted
+{
+}

--- a/src/Attributes/Events/Deleting.php
+++ b/src/Attributes/Events/Deleting.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Attributes\Events;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Deleting
+{
+}

--- a/src/Attributes/Events/ForceDeleted.php
+++ b/src/Attributes/Events/ForceDeleted.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Attributes\Events;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class ForceDeleted
+{
+}

--- a/src/Attributes/Events/ForceDeleting.php
+++ b/src/Attributes/Events/ForceDeleting.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Attributes\Events;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class ForceDeleting
+{
+}

--- a/src/Attributes/Events/Replicating.php
+++ b/src/Attributes/Events/Replicating.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Attributes\Events;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Replicating
+{
+}

--- a/src/Attributes/Events/Restored.php
+++ b/src/Attributes/Events/Restored.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Attributes\Events;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Restored
+{
+}

--- a/src/Attributes/Events/Restoring.php
+++ b/src/Attributes/Events/Restoring.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Attributes\Events;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Restoring
+{
+}

--- a/src/Attributes/Events/Retrieved.php
+++ b/src/Attributes/Events/Retrieved.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Attributes\Events;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Retrieved
+{
+}

--- a/src/Attributes/Events/Saved.php
+++ b/src/Attributes/Events/Saved.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Attributes\Events;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Saved
+{
+}

--- a/src/Attributes/Events/Saving.php
+++ b/src/Attributes/Events/Saving.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Attributes\Events;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Saving
+{
+}

--- a/src/Attributes/Events/Updated.php
+++ b/src/Attributes/Events/Updated.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Attributes\Events;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Updated
+{
+}

--- a/src/Attributes/Events/Updating.php
+++ b/src/Attributes/Events/Updating.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Attributes\Events;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Updating
+{
+}

--- a/src/Concerns/EventsHandler.php
+++ b/src/Concerns/EventsHandler.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+use WendellAdriel\Lift\Attributes\Events\Created;
+use WendellAdriel\Lift\Attributes\Events\Creating;
+use WendellAdriel\Lift\Attributes\Events\Deleted;
+use WendellAdriel\Lift\Attributes\Events\Deleting;
+use WendellAdriel\Lift\Attributes\Events\ForceDeleted;
+use WendellAdriel\Lift\Attributes\Events\ForceDeleting;
+use WendellAdriel\Lift\Attributes\Events\Replicating;
+use WendellAdriel\Lift\Attributes\Events\Restored;
+use WendellAdriel\Lift\Attributes\Events\Restoring;
+use WendellAdriel\Lift\Attributes\Events\Retrieved;
+use WendellAdriel\Lift\Attributes\Events\Saved;
+use WendellAdriel\Lift\Attributes\Events\Saving;
+use WendellAdriel\Lift\Attributes\Events\Updated;
+use WendellAdriel\Lift\Attributes\Events\Updating;
+
+trait EventsHandler
+{
+    private static ?array $modelEventMethods = null;
+
+    private static function eventHandlerMethods(): array
+    {
+        if (is_null(self::$modelEventMethods)) {
+            self::buildEventHandlers(new static());
+        }
+
+        return self::$modelEventMethods;
+    }
+
+    private static function buildEventHandlers(Model $model): void
+    {
+        self::$modelEventMethods = [];
+
+        $methods = self::getMethodsWithAttributes($model);
+
+        self::$modelEventMethods['retrieved'] = self::getMethodForAttribute($methods, Retrieved::class);
+        self::$modelEventMethods['creating'] = self::getMethodForAttribute($methods, Creating::class);
+        self::$modelEventMethods['created'] = self::getMethodForAttribute($methods, Created::class);
+        self::$modelEventMethods['updating'] = self::getMethodForAttribute($methods, Updating::class);
+        self::$modelEventMethods['updated'] = self::getMethodForAttribute($methods, Updated::class);
+        self::$modelEventMethods['saving'] = self::getMethodForAttribute($methods, Saving::class);
+        self::$modelEventMethods['saved'] = self::getMethodForAttribute($methods, Saved::class);
+        self::$modelEventMethods['deleting'] = self::getMethodForAttribute($methods, Deleting::class);
+        self::$modelEventMethods['deleted'] = self::getMethodForAttribute($methods, Deleted::class);
+        self::$modelEventMethods['forceDeleting'] = self::getMethodForAttribute($methods, ForceDeleting::class);
+        self::$modelEventMethods['forceDeleted'] = self::getMethodForAttribute($methods, ForceDeleted::class);
+        self::$modelEventMethods['restoring'] = self::getMethodForAttribute($methods, Restoring::class);
+        self::$modelEventMethods['restored'] = self::getMethodForAttribute($methods, Restored::class);
+        self::$modelEventMethods['replicating'] = self::getMethodForAttribute($methods, Replicating::class);
+    }
+
+    private static function handleEvent(?Model $model, string $event): void
+    {
+        self::eventHandlerMethods()[$event]?->method->invoke($model, $model);
+    }
+}

--- a/src/Support/MethodInfo.php
+++ b/src/Support/MethodInfo.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Support;
+
+use Illuminate\Support\Collection;
+use ReflectionAttribute;
+use ReflectionMethod;
+
+final class MethodInfo
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly ReflectionMethod $method,
+        /**
+         * @var Collection<ReflectionAttribute>
+         */
+        public readonly Collection $attributes
+    ) {
+    }
+}

--- a/tests/Datasets/Car.php
+++ b/tests/Datasets/Car.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Log;
+use WendellAdriel\Lift\Attributes\Events\ForceDeleted;
+use WendellAdriel\Lift\Attributes\Events\ForceDeleting;
+use WendellAdriel\Lift\Attributes\Events\Restored;
+use WendellAdriel\Lift\Attributes\Events\Restoring;
+use WendellAdriel\Lift\Lift;
+
+class Car extends Model
+{
+    use Lift;
+    use SoftDeletes;
+
+    public int $id;
+
+    public string $name;
+
+    #[ForceDeleting]
+    public function onForceDeleting(Car $car): void
+    {
+        Log::info('onForceDeleting has been called');
+    }
+
+    #[ForceDeleted]
+    public function onForceDeleted(Car $car): void
+    {
+        Log::info('onForceDeleted has been called');
+    }
+
+    #[Restoring]
+    public function onRestoring(Car $car): void
+    {
+        Log::info('onRestoring has been called');
+    }
+
+    #[Restored]
+    public function onRestored(Car $car): void
+    {
+        Log::info('onRestored has been called');
+    }
+}

--- a/tests/Datasets/Product.php
+++ b/tests/Datasets/Product.php
@@ -6,7 +6,18 @@ namespace Tests\Datasets;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Log;
 use WendellAdriel\Lift\Attributes\Cast;
+use WendellAdriel\Lift\Attributes\Events\Created;
+use WendellAdriel\Lift\Attributes\Events\Creating;
+use WendellAdriel\Lift\Attributes\Events\Deleted;
+use WendellAdriel\Lift\Attributes\Events\Deleting;
+use WendellAdriel\Lift\Attributes\Events\Replicating;
+use WendellAdriel\Lift\Attributes\Events\Retrieved;
+use WendellAdriel\Lift\Attributes\Events\Saved;
+use WendellAdriel\Lift\Attributes\Events\Saving;
+use WendellAdriel\Lift\Attributes\Events\Updated;
+use WendellAdriel\Lift\Attributes\Events\Updating;
 use WendellAdriel\Lift\Lift;
 
 class Product extends Model
@@ -34,4 +45,64 @@ class Product extends Model
         'expires_at',
         'json_column',
     ];
+
+    #[Retrieved]
+    public function onRetrieved(Product $product): void
+    {
+        Log::info('onRetrieved has been called');
+    }
+
+    #[Creating]
+    public function onCreating(Product $product): void
+    {
+        Log::info('onCreating has been called');
+    }
+
+    #[Created]
+    public function onCreated(Product $product): void
+    {
+        Log::info('onCreated has been called');
+    }
+
+    #[Updating]
+    public function onUpdating(Product $product): void
+    {
+        Log::info('onUpdating has been called');
+    }
+
+    #[Updated]
+    public function onUpdated(Product $product): void
+    {
+        Log::info('onUpdated has been called');
+    }
+
+    #[Saving]
+    public function onSaving(Product $product): void
+    {
+        Log::info('onSaving has been called');
+    }
+
+    #[Saved]
+    public function onSaved(Product $product): void
+    {
+        Log::info('onSaved has been called');
+    }
+
+    #[Deleting]
+    public function onDeleting(Product $product): void
+    {
+        Log::info('onDeleting has been called');
+    }
+
+    #[Deleted]
+    public function onDeleted(Product $product): void
+    {
+        Log::info('onDeleted has been called');
+    }
+
+    #[Replicating]
+    public function onReplicating(Product $product): void
+    {
+        Log::info('onReplicating has been called');
+    }
 }

--- a/tests/Feature/Events/SoftDeletesEventsTest.php
+++ b/tests/Feature/Events/SoftDeletesEventsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Log;
+use Tests\Datasets\Car;
+
+it('force deletion event handlers get called', function () {
+    $car = Car::castAndCreate(['name' => 'yellow card']);
+
+    Log::shouldReceive('info')->withArgs(fn ($message) => str_contains($message, 'onForceDeleting has been called'));
+    Log::shouldReceive('info')->withArgs(fn ($message) => str_contains($message, 'onForceDeleted has been called'));
+
+    $car->forceDelete();
+
+    $this->assertTrue(true);
+});
+
+it('restore event handlers get called', function () {
+    $car = Car::castAndCreate(['name' => 'yellow card']);
+
+    $car->delete();
+
+    Log::shouldReceive('info')->withArgs(fn ($message) => str_contains($message, 'onRestoring has been called'));
+    Log::shouldReceive('info')->withArgs(fn ($message) => str_contains($message, 'onRestored has been called'));
+
+    $car->restore();
+
+    $this->assertTrue(true);
+});

--- a/tests/Feature/Events/StandardEventsTest.php
+++ b/tests/Feature/Events/StandardEventsTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Log;
+use Tests\Datasets\Product;
+use Tests\Datasets\ProductConfig;
+
+it('onRetrieved method gets called', function () {
+    $product = Product::castAndCreate([
+        'name' => 'Product 1',
+        'price' => '10.99',
+        'random_number' => '123',
+        'expires_at' => '2023-12-31 23:59:59',
+        'json_column' => ['foo' => 'bar'],
+    ]);
+    Log::shouldReceive('info')->withArgs(fn ($message) => str_contains($message, 'onRetrieved has been called'));
+    $product->refresh();
+    $this->assertTrue(true);
+});
+
+it('cause events on a model without event listeners', function () {
+    Log::shouldReceive('info')->never()->withArgs(fn ($message) => str_contains($message, 'onCreating has been called'));
+    Log::shouldReceive('info')->never()->withArgs(fn ($message) => str_contains($message, 'onCreated has been called'));
+    Log::shouldReceive('info')->never()->withArgs(fn ($message) => str_contains($message, 'onSaving has been called'));
+    Log::shouldReceive('info')->never()->withArgs(fn ($message) => str_contains($message, 'onSaved has been called'));
+    $product = ProductConfig::create([
+        'name' => 'Product 1',
+        'price' => '10.99',
+        'random_number' => '123',
+        'expires_at' => '2023-12-31 23:59:59',
+    ]);
+});
+
+it('creation event handlers get called', function () {
+    Log::shouldReceive('info')->withArgs(fn ($message) => str_contains($message, 'onCreating has been called'));
+    Log::shouldReceive('info')->withArgs(fn ($message) => str_contains($message, 'onCreated has been called'));
+    Log::shouldReceive('info')->withArgs(fn ($message) => str_contains($message, 'onSaving has been called'));
+    Log::shouldReceive('info')->withArgs(fn ($message) => str_contains($message, 'onSaved has been called'));
+
+    Product::castAndCreate([
+        'name' => 'Product 1',
+        'price' => '10.99',
+        'random_number' => '123',
+        'expires_at' => '2023-12-31 23:59:59',
+        'json_column' => ['foo' => 'bar'],
+    ]);
+
+    $this->assertTrue(true);
+});
+
+it('update event handlers get called', function () {
+    $product = Product::castAndCreate([
+        'name' => 'Product 1',
+        'price' => '10.99',
+        'random_number' => '123',
+        'expires_at' => '2023-12-31 23:59:59',
+        'json_column' => ['foo' => 'bar'],
+    ]);
+
+    Log::shouldReceive('info')->withArgs(fn ($message) => str_contains($message, 'onUpdating has been called'));
+    Log::shouldReceive('info')->withArgs(fn ($message) => str_contains($message, 'onSaving has been called'));
+    Log::shouldReceive('info')->withArgs(fn ($message) => str_contains($message, 'onSaved has been called'));
+    Log::shouldReceive('info')->withArgs(fn ($message) => str_contains($message, 'onUpdated has been called'));
+
+    $product->update(['name' => 'Product11']);
+    $this->assertTrue(true);
+});
+it('deletion event handlers get called', function () {
+    $product = Product::castAndCreate([
+        'name' => 'Product 1',
+        'price' => '10.99',
+        'random_number' => '123',
+        'expires_at' => '2023-12-31 23:59:59',
+        'json_column' => ['foo' => 'bar'],
+    ]);
+
+    Log::shouldReceive('info')->withArgs(fn ($message) => str_contains($message, 'onDeleting has been called'));
+    Log::shouldReceive('info')->withArgs(fn ($message) => str_contains($message, 'onDeleted has been called'));
+
+    $product->delete();
+    $this->assertTrue(true);
+});
+
+it('onReplicating method gets called', function () {
+    $product = Product::castAndCreate([
+        'name' => 'Product 1',
+        'price' => '10.99',
+        'random_number' => '123',
+        'expires_at' => '2023-12-31 23:59:59',
+        'json_column' => ['foo' => 'bar'],
+    ]);
+
+    Log::shouldReceive('info')->withArgs(fn ($message) => str_contains($message, 'onReplicating has been called'));
+
+    $product->replicate();
+    $this->assertTrue(true);
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -178,6 +178,13 @@ abstract class TestCase extends BaseTestCase
             $table->string('password');
             $table->timestamps();
         });
+
+        Schema::create('cars', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->softDeletes();
+            $table->timestamps();
+        });
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
Handling Events with listeners on your Model with lifts fantastic syntax, Thanks for making this library IMHO this should be part of the framework seems like a no-brainer to me ever since I saw Caleb's talk on Laracon Us this year.

This PR supports every Model Event [documented](https://laravel.com/docs/10.x/eloquent#events).

```php
#[Updated]
public function onUpdated(Product $product): void
{
    Log::info('onUpdated has been called');
}
```

I'm not sure what to name the Attributes or make them even as one configurable Attribute but I left it for what it is for now, I'm happy to discuss and change thought.

Right now they are named exactly as documented just capitalized other Ideas would be:

`#[OnUpdated]`

or 

`#[ListeningOn('updated')]`