### PR TITLE
Fix casting with custom column name

### DIFF
--- a/src/Concerns/CastValues.php
+++ b/src/Concerns/CastValues.php
@@ -7,6 +7,7 @@ namespace WendellAdriel\Lift\Concerns;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use WendellAdriel\Lift\Attributes\Cast;
+use WendellAdriel\Lift\Attributes\Column;
 use WendellAdriel\Lift\Attributes\Config;
 use WendellAdriel\Lift\Support\PropertyInfo;
 
@@ -88,6 +89,26 @@ trait CastValues
                 continue;
             }
 
+            $configAttribute = $property->attributes->first(fn ($attribute) => $attribute->getName() === Config::class);
+            if (filled($configAttribute)) {
+                $configAttribute = $configAttribute->newInstance();
+                if (filled($configAttribute->column)) {
+                    self::$modelCastableProperties[static::class][$configAttribute->column] = $castAttribute->getArguments()[0];
+
+                    continue;
+                }
+            }
+
+            $columnAttribute = $property->attributes->first(fn ($attribute) => $attribute->getName() === Column::class);
+            if (filled($columnAttribute)) {
+                $columnAttribute = $columnAttribute->newInstance();
+                if (filled($columnAttribute->name)) {
+                    self::$modelCastableProperties[static::class][$columnAttribute->name] = $castAttribute->getArguments()[0];
+
+                    continue;
+                }
+            }
+
             self::$modelCastableProperties[static::class][$property->name] = $castAttribute->getArguments()[0];
         }
 
@@ -101,6 +122,22 @@ trait CastValues
             $configAttribute = $configAttribute->newInstance();
             if (blank($configAttribute->cast)) {
                 continue;
+            }
+
+            if (filled($configAttribute->column)) {
+                self::$modelCastableProperties[static::class][$configAttribute->column] = $configAttribute->cast;
+
+                continue;
+            }
+
+            $columnAttribute = $property->attributes->first(fn ($attribute) => $attribute->getName() === Column::class);
+            if (filled($columnAttribute)) {
+                $columnAttribute = $columnAttribute->newInstance();
+                if (filled($columnAttribute->name)) {
+                    self::$modelCastableProperties[static::class][$columnAttribute->name] = $configAttribute->cast;
+
+                    continue;
+                }
             }
 
             self::$modelCastableProperties[static::class][$property->name] = $configAttribute->cast;

--- a/tests/Datasets/ProductColumn.php
+++ b/tests/Datasets/ProductColumn.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Model;
+use WendellAdriel\Lift\Attributes\Cast;
+use WendellAdriel\Lift\Attributes\Column;
+use WendellAdriel\Lift\Attributes\Config;
+use WendellAdriel\Lift\Attributes\DB;
+use WendellAdriel\Lift\Lift;
+
+#[DB(table: 'products')]
+class ProductColumn extends Model
+{
+    use Lift;
+
+    public string $name;
+
+    #[Cast('float')]
+    #[Config(column: 'price')]
+    public float $product_price;
+
+    #[Cast('int')]
+    #[Column(name: 'random_number')]
+    public int $number;
+
+    #[Cast('immutable_datetime')]
+    public CarbonImmutable $expires_at;
+
+    #[Cast('array')]
+    public ?array $json_column;
+
+    protected $fillable = [
+        'name',
+        'price',
+        'random_number',
+        'expires_at',
+        'json_column',
+    ];
+}

--- a/tests/Feature/CastTest.php
+++ b/tests/Feature/CastTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Tests\Datasets\Product;
+use Tests\Datasets\ProductColumn;
 
 it('casts values when creating model', function () {
     $product = Product::castAndCreate([
@@ -129,6 +130,25 @@ it('casts values when retrieving model', function () {
         'expires_at' => '2023-12-31 23:59:59',
         'json_column' => '{"foo": "bar"}',
     ]);
+    $product = Product::query()->first();
+
+    expect($product->name)->toBe('Product 1')
+        ->and($product->price)->toBe(10.99)
+        ->and($product->random_number)->toBe(123)
+        ->and($product->expires_at)->toBeInstanceOf(Carbon\CarbonImmutable::class)
+        ->and($product->expires_at->format('Y-m-d H:i:s'))->toBe('2023-12-31 23:59:59')
+        ->and($product->json_column)->toBe(['foo' => 'bar']);
+});
+
+it('casts values when retrieving model with custom columns', function () {
+    ProductColumn::create([
+        'name' => 'Product 1',
+        'price' => '10.99',
+        'random_number' => '123',
+        'expires_at' => '2023-12-31 23:59:59',
+        'json_column' => ['foo' => 'bar'],
+    ]);
+    
     $product = Product::query()->first();
 
     expect($product->name)->toBe('Product 1')

--- a/tests/Feature/CastTest.php
+++ b/tests/Feature/CastTest.php
@@ -148,7 +148,7 @@ it('casts values when retrieving model with custom columns', function () {
         'expires_at' => '2023-12-31 23:59:59',
         'json_column' => ['foo' => 'bar'],
     ]);
-    
+
     $product = Product::query()->first();
 
     expect($product->name)->toBe('Product 1')


### PR DESCRIPTION
Cast attributes did not work in conjunction with column attributes. Maybe there is a better way to do this, but for now, it works!

Ps.: Unfortunately I still haven't been able to get the `castAndCreate` and `castAndUpdate` methods to work with the column attribute.