### PR TITLE
Add attribute to ignore public properties

### DIFF
--- a/src/Attributes/IgnoreProperties.php
+++ b/src/Attributes/IgnoreProperties.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final class IgnoreProperties
+{
+    public array $ignoredProperties;
+
+    public function __construct(
+        string $ignoredProperty,
+        string ...$additionalIgnoredProperties
+    ) {
+        $this->ignoredProperties = [$ignoredProperty, ...$additionalIgnoredProperties];
+    }
+}

--- a/src/Attributes/IgnoreProperties.php
+++ b/src/Attributes/IgnoreProperties.php
@@ -9,6 +9,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 final class IgnoreProperties
 {
+    /** @var string[] */
     public array $ignoredProperties;
 
     public function __construct(

--- a/src/Lift.php
+++ b/src/Lift.php
@@ -8,10 +8,12 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 use Illuminate\Validation\ValidationException;
+use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionMethod;
 use ReflectionProperty;
+use WendellAdriel\Lift\Attributes\IgnoreProperties;
 use WendellAdriel\Lift\Concerns\AttributesGuard;
 use WendellAdriel\Lift\Concerns\CastValues;
 use WendellAdriel\Lift\Concerns\CustomPrimary;
@@ -183,6 +185,10 @@ trait Lift
 
     protected static function ignoredProperties(): array
     {
+        $reflectionClass = new ReflectionClass(self::class);
+        $ignoredProperties = collect($reflectionClass->getAttributes(IgnoreProperties::class))
+            ->flatMap(fn (ReflectionAttribute $attribute) => $attribute->getArguments());
+
         return [
             'incrementing',
             'preventsLazyLoading',
@@ -193,6 +199,7 @@ trait Lift
             'manyMethods',
             'timestamps',
             'usesUniqueIds',
+            ...$ignoredProperties,
         ];
     }
 

--- a/tests/Datasets/Product.php
+++ b/tests/Datasets/Product.php
@@ -15,11 +15,14 @@ use WendellAdriel\Lift\Attributes\Cast;
 use WendellAdriel\Lift\Attributes\Events\Dispatches;
 use WendellAdriel\Lift\Attributes\Events\Listener;
 use WendellAdriel\Lift\Attributes\Events\Observer;
+use WendellAdriel\Lift\Attributes\IgnoreProperties;
 use WendellAdriel\Lift\Lift;
 
 #[Observer(ProductObserver::class)]
 #[Dispatches(ProductSaving::class)]
 #[Dispatches(ProductSaved::class, 'saved')]
+#[IgnoreProperties('hash', 'hash2')]
+#[IgnoreProperties('hash3')]
 class Product extends Model
 {
     use Lift;
@@ -37,6 +40,12 @@ class Product extends Model
 
     #[Cast('array')]
     public ?array $json_column;
+
+    public string $hash;
+
+    public string $hash2;
+
+    public string $hash3;
 
     protected $fillable = [
         'name',

--- a/tests/Feature/IgnoredPropertiesTest.php
+++ b/tests/Feature/IgnoredPropertiesTest.php
@@ -8,7 +8,7 @@ use Tests\Datasets\User;
 it('ignores no additional properties if not set', function () {
     $rMethod = new ReflectionMethod(User::class, 'ignoredProperties');
     expect($rMethod->invoke(null))
-        ->toBe([
+        ->toMatchArray([
             'incrementing',
             'preventsLazyLoading',
             'exists',
@@ -24,7 +24,7 @@ it('ignores no additional properties if not set', function () {
 it('ignores additional properties', function () {
     $rMethod = new ReflectionMethod(Product::class, 'ignoredProperties');
     expect($rMethod->invoke(null))
-        ->toBe([
+        ->toMatchArray([
             'incrementing',
             'preventsLazyLoading',
             'exists',

--- a/tests/Feature/IgnoredPropertiesTest.php
+++ b/tests/Feature/IgnoredPropertiesTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Tests\Datasets\Product;
+use Tests\Datasets\User;
+
+it('ignores no additional properties if not set', function () {
+    $rMethod = new ReflectionMethod(User::class, 'ignoredProperties');
+    expect($rMethod->invoke(null))
+        ->toBe([
+            'incrementing',
+            'preventsLazyLoading',
+            'exists',
+            'wasRecentlyCreated',
+            'snakeAttributes',
+            'encrypter',
+            'manyMethods',
+            'timestamps',
+            'usesUniqueIds',
+        ]);
+});
+
+it('ignores additional properties', function () {
+    $rMethod = new ReflectionMethod(Product::class, 'ignoredProperties');
+    expect($rMethod->invoke(null))
+        ->toBe([
+            'incrementing',
+            'preventsLazyLoading',
+            'exists',
+            'wasRecentlyCreated',
+            'snakeAttributes',
+            'encrypter',
+            'manyMethods',
+            'timestamps',
+            'usesUniqueIds',
+            'hash',
+            'hash2',
+            'hash3',
+        ]);
+});


### PR DESCRIPTION
Adds the ability to ignore public properties from models without overriding the `ignoredProperties` method.