### PR TITLE
fix having stale properties after refreshing a model

### DIFF
--- a/src/Lift.php
+++ b/src/Lift.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace WendellAdriel\Lift;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
-use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 use Illuminate\Validation\ValidationException;
@@ -185,15 +183,13 @@ trait Lift
         }
     }
 
-    public function refresh(): static
+    public function setRawAttributes(array $attributes, $sync = false)
     {
-        parent::refresh();
+        parent::setRawAttributes($attributes, $sync);
 
-        foreach ($this->getOriginal() as $key => $value) {
+        foreach ($attributes as $key => $value) {
             $this->{$key} = $this->hasCast($key) ? $this->castAttribute($key, $value) : $value;
         }
-
-        return $this;
     }
 
     protected static function ignoredProperties(): array

--- a/src/Lift.php
+++ b/src/Lift.php
@@ -183,6 +183,14 @@ trait Lift
         }
     }
 
+    public function refresh(): static
+    {
+        parent::refresh();
+        static::fillProperties($this);
+
+        return $this;
+    }
+
     protected static function ignoredProperties(): array
     {
         $reflectionClass = new ReflectionClass(self::class);

--- a/src/Lift.php
+++ b/src/Lift.php
@@ -187,25 +187,9 @@ trait Lift
 
     public function refresh(): static
     {
-        if (! $this->exists) {
-            return $this;
-        }
+        parent::refresh();
 
-        $this->setRawAttributes(
-            $this->setKeysForSelectQuery($this->newQueryWithoutScopes())
-                ->useWritePdo()
-                ->firstOrFail()
-                ->attributes
-        );
-
-        $this->load(collect($this->relations)->reject(function ($relation) {
-            return $relation instanceof Pivot
-                || (is_object($relation) && in_array(AsPivot::class, class_uses_recursive($relation), true));
-        })->keys()->all());
-
-        parent::syncOriginal();
-
-        foreach ($this->getAttributes() as $key => $value) {
+        foreach ($this->getOriginal() as $key => $value) {
             $this->{$key} = $this->hasCast($key) ? $this->castAttribute($key, $value) : $value;
         }
 

--- a/src/Lift.php
+++ b/src/Lift.php
@@ -190,6 +190,8 @@ trait Lift
         foreach ($attributes as $key => $value) {
             $this->{$key} = $this->hasCast($key) ? $this->castAttribute($key, $value) : $value;
         }
+
+        return $this;
     }
 
     protected static function ignoredProperties(): array

--- a/tests/Datasets/CategoryRefreshed.php
+++ b/tests/Datasets/CategoryRefreshed.php
@@ -18,7 +18,4 @@ class CategoryRefreshed extends Model
 
     #[Fillable]
     public string $title;
-
-    #[Fillable]
-    public int $sort;
 }

--- a/tests/Datasets/CategoryRefreshed.php
+++ b/tests/Datasets/CategoryRefreshed.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets;
+
+use Illuminate\Database\Eloquent\Model;
+use WendellAdriel\Lift\Attributes\Fillable;
+use WendellAdriel\Lift\Attributes\PrimaryKey;
+use WendellAdriel\Lift\Lift;
+
+class CategoryRefreshed extends Model
+{
+    use Lift;
+
+    #[PrimaryKey]
+    public int $id;
+
+    #[Fillable]
+    public int $sort;
+}

--- a/tests/Datasets/CategoryRefreshed.php
+++ b/tests/Datasets/CategoryRefreshed.php
@@ -17,5 +17,8 @@ class CategoryRefreshed extends Model
     public int $id;
 
     #[Fillable]
+    public string $title;
+
+    #[Fillable]
     public int $sort;
 }

--- a/tests/Feature/ModelRefreshTest.php
+++ b/tests/Feature/ModelRefreshTest.php
@@ -5,14 +5,13 @@ declare(strict_types=1);
 use Tests\Datasets\CategoryRefreshed;
 
 it('expects to refresh model attributes', function () {
-    $category = new CategoryRefreshed([
-        'title' => 'test',
-    ]);
-    $category->title = 'test updated';
+    $category = new CategoryRefreshed(['title' => 'test']);
     $category->save();
+
+    CategoryRefreshed::find($category->id)->update(['title' => 'test updated']); // indirect update
+
     $category->refresh();
 
-    expect($category->sort)->not->toBeNull();
     expect($category->title)->toBe('test updated');
 
 });

--- a/tests/Feature/ModelRefreshTest.php
+++ b/tests/Feature/ModelRefreshTest.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 use Tests\Datasets\CategoryRefreshed;
 
 it('expects to refresh model attributes', function () {
-    $user = new CategoryRefreshed();
-    $user->save();
-    $user->refresh();
+    $category = new CategoryRefreshed([
+        'title' => 'test',
+    ]);
+    $category->title = 'test updated';
+    $category->save();
+    $category->refresh();
 
-    expect($user->sort)->not->toBeNull();
+    expect($category->sort)->not->toBeNull();
+    expect($category->title)->toBe('test updated');
 
 });

--- a/tests/Feature/ModelRefreshTest.php
+++ b/tests/Feature/ModelRefreshTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Tests\Datasets\CategoryRefreshed;
+
+it('expects to refresh model attributes', function () {
+    $user = new CategoryRefreshed();
+    $user->save();
+    $user->refresh();
+
+    expect($user->sort)->not->toBeNull();
+
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -207,6 +207,7 @@ abstract class TestCase extends BaseTestCase
 
         Schema::create('category_refresheds', function (Blueprint $table) {
             $table->id();
+            $table->string('title');
             $table->integer('sort')->default(9999);
             $table->timestamps();
         });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -204,6 +204,12 @@ abstract class TestCase extends BaseTestCase
             $table->uuid('id')->primary();
             $table->timestamps();
         });
+
+        Schema::create('category_refresheds', function (Blueprint $table) {
+            $table->id();
+            $table->integer('sort')->default(9999);
+            $table->timestamps();
+        });
     }
 
     protected function getPackageProviders($app)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -208,7 +208,6 @@ abstract class TestCase extends BaseTestCase
         Schema::create('category_refresheds', function (Blueprint $table) {
             $table->id();
             $table->string('title');
-            $table->integer('sort')->default(9999);
             $table->timestamps();
         });
     }


### PR DESCRIPTION
Lift doesn't refill model attributes after refreshing a model.
In this PR I have fixed it and added a test.