### PR TITLE
Refactor reflection parts

### DIFF
--- a/src/Lift.php
+++ b/src/Lift.php
@@ -279,14 +279,15 @@ trait Lift
 
     private static function getModelPublicMethods(Model $model): array
     {
-        $reflectionClass = new ReflectionClass($model);
-        $methods = [];
+        return array_column(static::getModelPublicReflectionMethods($model), 'name');
+    }
 
-        foreach ($reflectionClass->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
-            $methods[] = $method->getName();
-        }
-
-        return $methods;
+    /**
+     * @return array<ReflectionMethod>
+     */
+    private static function getModelPublicReflectionMethods(Model $model): array
+    {
+        return (new ReflectionClass($model))->getMethods(ReflectionMethod::IS_PUBLIC);
     }
 
     /**

--- a/src/Lift.php
+++ b/src/Lift.php
@@ -262,19 +262,25 @@ trait Lift
         return collect($result);
     }
 
+    /**
+     * @return array<string>
+     */
     private static function getModelPublicProperties(Model $model): array
     {
-        $reflectionClass = new ReflectionClass($model);
-        $properties = [];
+        return array_column(static::getModelPublicReflectionProperties($model), 'name');
+    }
 
-        foreach ($reflectionClass->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
-            if (in_array($property->getName(), self::ignoredProperties())) {
-                continue;
-            }
-            $properties[] = $property->getName();
-        }
+    /**
+     * @return array<ReflectionProperty>
+     */
+    private static function getModelPublicReflectionProperties(Model $model): array
+    {
+        $properties = (new ReflectionClass($model))->getProperties(ReflectionProperty::IS_PUBLIC);
 
-        return $properties;
+        return array_values(array_diff_key(
+            array_combine(array_column($properties, 'name'), $properties),
+            array_flip(static::ignoredProperties())
+        ));
     }
 
     private static function getModelPublicMethods(Model $model): array


### PR DESCRIPTION
Removed the need for recreating reflection properties and methods in the `get*WithAttributes` methods and improved the logic of some parts to be more crisp.