### PR TITLE
Fixing Namespace Option Ending with Backslash in LiftMigration Command

### DIFF
--- a/src/Console/Commands/LiftMigration.php
+++ b/src/Console/Commands/LiftMigration.php
@@ -29,7 +29,7 @@ final class LiftMigration extends Command
     public function handle(): int
     {
         try {
-            $class = $this->option('namespace') . '\\' . $this->argument('model'); // @phpstan-ignore-line
+            $class = rtrim($this->option('namespace'), '\\') . '\\' . $this->argument('model'); // @phpstan-ignore-line
 
             if (! class_exists($class)) {
                 $this->error("Model {$class} not found.");

--- a/tests/Feature/LiftMigrationTest.php
+++ b/tests/Feature/LiftMigrationTest.php
@@ -13,6 +13,17 @@ describe('CREATE TABLE', function () {
 
         unlink($migrationClass);
     });
+
+    it('generates a migration file for a model if namespace ends with slash', function () {
+        $migrationClass = database_path('migrations/' . date('Y_m_d_His') . '_create_users_migration_table.php');
+
+        $this->artisan('lift:migration UserMigration --namespace=Tests\\\Datasets\\')
+            ->assertExitCode(0);
+
+        expect($migrationClass)->toBeFileWithContent(UserMigrationCreate());
+
+        unlink($migrationClass);
+    });
 });
 
 describe('UPDATE TABLE', function () {
@@ -20,6 +31,17 @@ describe('UPDATE TABLE', function () {
         $migrationClass = database_path('migrations/' . date('Y_m_d_His') . '_update_users_migrated_table.php');
 
         $this->artisan('lift:migration UserMigratedUpdateTable --namespace=Tests\\\Datasets')
+            ->assertExitCode(0);
+
+        expect($migrationClass)->toBeFileWithContent(UserMigrationAddColumns());
+
+        unlink($migrationClass);
+    });
+
+    it('generates a migration file for a model adding and dropping columns if namespace ends with slash', function () {
+        $migrationClass = database_path('migrations/' . date('Y_m_d_His') . '_update_users_migrated_table.php');
+
+        $this->artisan('lift:migration UserMigratedUpdateTable --namespace=Tests\\\Datasets\\')
             ->assertExitCode(0);
 
         expect($migrationClass)->toBeFileWithContent(UserMigrationAddColumns());


### PR DESCRIPTION

This PR addresses an issue in the `LiftMigration` command where the namespace option could end with a backslash (`\\`). In the original code, if the namespace option ended with a backslash, it would result in two consecutive backslashes when concatenating the model name. This could lead to unexpected issues.

In this PR, I've used the `rtrim` function to ensure that the namespace option does not end with a backslash before concatenating the model name.

Here's the modified line of code:
```php
$class = rtrim($this->option('namespace'), '\\') . '\\' . $this->argument('model'); // @phpstan-ignore-line
```

This change has passed all tests, including a new test case specifically designed to check if a migration file is correctly generated when the namespace option ends with two backslashes (`\\`).

Please review this PR and feel free to provide any feedback or suggestions.