### PR TITLE
Support named parameter 'type' in the Cast attribute.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+* text=auto eol=lf
+
 /.github                export-ignore
 /art                    export-ignore
 /tests                  export-ignore

--- a/src/Attributes/Cast.php
+++ b/src/Attributes/Cast.php
@@ -9,7 +9,5 @@ use Attribute;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class Cast
 {
-    public function __construct(public string $type)
-    {
-    }
+    public function __construct(public string $type) {}
 }

--- a/src/Attributes/Column.php
+++ b/src/Attributes/Column.php
@@ -12,6 +12,5 @@ final class Column
     public function __construct(
         public ?string $name = null,
         public mixed $default = null,
-    ) {
-    }
+    ) {}
 }

--- a/src/Attributes/Config.php
+++ b/src/Attributes/Config.php
@@ -25,6 +25,5 @@ final class Config
          * @var array<string, string>
          */
         public array $messages = [],
-    ) {
-    }
+    ) {}
 }

--- a/src/Attributes/CreateRules.php
+++ b/src/Attributes/CreateRules.php
@@ -18,6 +18,5 @@ final class CreateRules
          * @var array<string, string>
          */
         public array $messages = [],
-    ) {
-    }
+    ) {}
 }

--- a/src/Attributes/DB.php
+++ b/src/Attributes/DB.php
@@ -13,6 +13,5 @@ final class DB
         public ?string $connection = null,
         public ?string $table = null,
         public bool $timestamps = true,
-    ) {
-    }
+    ) {}
 }

--- a/src/Attributes/Events/Dispatches.php
+++ b/src/Attributes/Events/Dispatches.php
@@ -12,6 +12,5 @@ final class Dispatches
     public function __construct(
         public string $eventClass,
         public string $event = ''
-    ) {
-    }
+    ) {}
 }

--- a/src/Attributes/Events/Listener.php
+++ b/src/Attributes/Events/Listener.php
@@ -12,6 +12,5 @@ final class Listener
     public function __construct(
         public string $event = '',
         public bool $queue = false
-    ) {
-    }
+    ) {}
 }

--- a/src/Attributes/Events/Observer.php
+++ b/src/Attributes/Events/Observer.php
@@ -11,6 +11,5 @@ final class Observer
 {
     public function __construct(
         public string $observer
-    ) {
-    }
+    ) {}
 }

--- a/src/Attributes/Fillable.php
+++ b/src/Attributes/Fillable.php
@@ -7,6 +7,4 @@ namespace WendellAdriel\Lift\Attributes;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Fillable
-{
-}
+final class Fillable {}

--- a/src/Attributes/Hidden.php
+++ b/src/Attributes/Hidden.php
@@ -7,6 +7,4 @@ namespace WendellAdriel\Lift\Attributes;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Hidden
-{
-}
+final class Hidden {}

--- a/src/Attributes/Immutable.php
+++ b/src/Attributes/Immutable.php
@@ -7,6 +7,4 @@ namespace WendellAdriel\Lift\Attributes;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Immutable
-{
-}
+final class Immutable {}

--- a/src/Attributes/PrimaryKey.php
+++ b/src/Attributes/PrimaryKey.php
@@ -12,6 +12,5 @@ final class PrimaryKey
     public function __construct(
         public string $type = 'int',
         public bool $incrementing = true,
-    ) {
-    }
+    ) {}
 }

--- a/src/Attributes/Rules.php
+++ b/src/Attributes/Rules.php
@@ -18,6 +18,5 @@ final class Rules
          * @var array<string, string>
          */
         public array $messages = [],
-    ) {
-    }
+    ) {}
 }

--- a/src/Attributes/UpdateRules.php
+++ b/src/Attributes/UpdateRules.php
@@ -18,6 +18,5 @@ final class UpdateRules
          * @var array<string, string>
          */
         public array $messages = [],
-    ) {
-    }
+    ) {}
 }

--- a/src/Attributes/Watch.php
+++ b/src/Attributes/Watch.php
@@ -11,6 +11,5 @@ final class Watch
 {
     public function __construct(
         public string $event,
-    ) {
-    }
+    ) {}
 }

--- a/src/Concerns/CastValues.php
+++ b/src/Concerns/CastValues.php
@@ -89,11 +89,16 @@ trait CastValues
                 continue;
             }
 
+            $castAttribute = $castAttribute->newInstance();
+            if (blank($castAttribute->type)) {
+                continue;
+            }
+
             $configAttribute = $property->attributes->first(fn ($attribute) => $attribute->getName() === Config::class);
             if (filled($configAttribute)) {
                 $configAttribute = $configAttribute->newInstance();
                 if (filled($configAttribute->column)) {
-                    self::$modelCastableProperties[static::class][$configAttribute->column] = $castAttribute->getArguments()[0];
+                    self::$modelCastableProperties[static::class][$configAttribute->column] = $castAttribute->type;
 
                     continue;
                 }
@@ -103,13 +108,13 @@ trait CastValues
             if (filled($columnAttribute)) {
                 $columnAttribute = $columnAttribute->newInstance();
                 if (filled($columnAttribute->name)) {
-                    self::$modelCastableProperties[static::class][$columnAttribute->name] = $castAttribute->getArguments()[0];
+                    self::$modelCastableProperties[static::class][$columnAttribute->name] = $castAttribute->type;
 
                     continue;
                 }
             }
 
-            self::$modelCastableProperties[static::class][$property->name] = $castAttribute->getArguments()[0];
+            self::$modelCastableProperties[static::class][$property->name] = $castAttribute->type;
         }
 
         $castableProperties = self::getPropertiesForAttributes($properties, [Config::class]);

--- a/src/Console/Commands/LiftMigration.php
+++ b/src/Console/Commands/LiftMigration.php
@@ -116,13 +116,13 @@ final class LiftMigration extends Command
                 continue;
             }
 
-            if (blank($type)) {
+            if ($type === null) {
                 $result[] = "\$table->string('{$property}');";
 
                 continue;
             }
 
-            if ($this->isDateType($type)) { // @phpstan-ignore-line
+            if ($this->isDateType($type)) {
                 if (
                     $modelHasTimestamps &&
                     ($property === $model->getCreatedAtColumn() || $property === $model->getUpdatedAtColumn())
@@ -134,17 +134,17 @@ final class LiftMigration extends Command
                     continue;
                 }
 
-                $result[] = $this->generateMigrationCall('timestamp', $type, $property, $tableExists, $modelColumns); // @phpstan-ignore-line
+                $result[] = $this->generateMigrationCall('timestamp', $type, $property, $tableExists, $modelColumns);
             }
 
             $result[] = match (true) {
-                $type->getName() === 'bool' => $this->generateMigrationCall('boolean', $type, $property, $tableExists, $modelColumns), // @phpstan-ignore-line
-                $type->getName() === 'int' => $this->generateMigrationCall('integer', $type, $property, $tableExists, $modelColumns), // @phpstan-ignore-line
-                $type->getName() === 'float' => $this->generateMigrationCall('float', $type, $property, $tableExists, $modelColumns), // @phpstan-ignore-line
-                $type->getName() === 'string' => $this->generateMigrationCall('string', $type, $property, $tableExists, $modelColumns), // @phpstan-ignore-line
-                $type->getName() === 'array' => $this->generateMigrationCall('json', $type, $property, $tableExists, $modelColumns), // @phpstan-ignore-line
-                $type->getName() === 'object' => $this->generateMigrationCall('json', $type, $property, $tableExists, $modelColumns), // @phpstan-ignore-line
-                default => $this->generateMigrationCall('string', $type, $property, $tableExists, $modelColumns), // @phpstan-ignore-line
+                $type->getName() === 'bool' => $this->generateMigrationCall('boolean', $type, $property, $tableExists, $modelColumns),
+                $type->getName() === 'int' => $this->generateMigrationCall('integer', $type, $property, $tableExists, $modelColumns),
+                $type->getName() === 'float' => $this->generateMigrationCall('float', $type, $property, $tableExists, $modelColumns),
+                $type->getName() === 'string' => $this->generateMigrationCall('string', $type, $property, $tableExists, $modelColumns),
+                $type->getName() === 'array' => $this->generateMigrationCall('json', $type, $property, $tableExists, $modelColumns),
+                $type->getName() === 'object' => $this->generateMigrationCall('json', $type, $property, $tableExists, $modelColumns),
+                default => $this->generateMigrationCall('string', $type, $property, $tableExists, $modelColumns),
             };
         }
 
@@ -176,7 +176,7 @@ final class LiftMigration extends Command
 
     private function buildPrimaryKeyMigrationCall(string $property, ?ReflectionNamedType $type): string
     {
-        return ! blank($type) && $type->getName() === 'int' // @phpstan-ignore-line
+        return $type !== null && $type->getName() === 'int'
             ? '$table->id();'
             : "\$table->string('{$property}')->primary();";
     }

--- a/src/Support/MethodInfo.php
+++ b/src/Support/MethodInfo.php
@@ -17,6 +17,5 @@ final class MethodInfo
          * @var Collection<ReflectionAttribute>
          */
         public readonly Collection $attributes
-    ) {
-    }
+    ) {}
 }

--- a/src/Support/PropertyInfo.php
+++ b/src/Support/PropertyInfo.php
@@ -16,6 +16,5 @@ final class PropertyInfo
          * @var Collection<ReflectionAttribute>
          */
         public readonly Collection $attributes,
-    ) {
-    }
+    ) {}
 }

--- a/tests/Datasets/LibraryBook.php
+++ b/tests/Datasets/LibraryBook.php
@@ -7,6 +7,4 @@ namespace Tests\Datasets;
 use WendellAdriel\Lift\Attributes\Relations\BelongsTo;
 
 #[BelongsTo(Library::class)]
-class LibraryBook extends Book
-{
-}
+class LibraryBook extends Book {}

--- a/tests/Datasets/PriceChangedEvent.php
+++ b/tests/Datasets/PriceChangedEvent.php
@@ -14,6 +14,5 @@ final class PriceChangedEvent
 
     public function __construct(
         public ProductWatch $product,
-    ) {
-    }
+    ) {}
 }

--- a/tests/Datasets/Product.php
+++ b/tests/Datasets/Product.php
@@ -29,16 +29,16 @@ class Product extends Model
 
     public string $name;
 
-    #[Cast('float')]
+    #[Cast(type: 'float')]
     public float $price;
 
-    #[Cast('int')]
+    #[Cast(type: 'int')]
     public int $random_number;
 
-    #[Cast('immutable_datetime')]
+    #[Cast(type: 'immutable_datetime')]
     public CarbonImmutable $expires_at;
 
-    #[Cast('array')]
+    #[Cast(type: 'array')]
     public ?array $json_column;
 
     public string $hash;

--- a/tests/Datasets/RandomNumberChangedEvent.php
+++ b/tests/Datasets/RandomNumberChangedEvent.php
@@ -14,6 +14,5 @@ final class RandomNumberChangedEvent
 
     public function __construct(
         public ProductWatch $product,
-    ) {
-    }
+    ) {}
 }

--- a/tests/Datasets/UserColumn.php
+++ b/tests/Datasets/UserColumn.php
@@ -38,7 +38,7 @@ class UserColumn extends Model
     public string $user_password;
 
     #[Fillable]
-    #[Cast('boolean')]
+    #[Cast(type: 'boolean')]
     #[Column(default: false)]
     public bool $active;
 

--- a/tests/Datasets/WorkBook.php
+++ b/tests/Datasets/WorkBook.php
@@ -7,6 +7,4 @@ namespace Tests\Datasets;
 use WendellAdriel\Lift\Attributes\Relations\BelongsTo;
 
 #[BelongsTo(User::class)]
-class WorkBook extends Book
-{
-}
+class WorkBook extends Book {}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -13,10 +13,7 @@ declare(strict_types=1);
 |
 */
 
-uses(
-    Tests\TestCase::class,
-    \Illuminate\Foundation\Testing\RefreshDatabase::class
-)->in('Feature');
+uses(Tests\TestCase::class)->in('Feature');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -29,7 +29,7 @@ uses(Tests\TestCase::class)->in('Feature');
 expect()->extend('toBeFileWithContent', function (string $fileContent) {
     test()->assertFileExists($this->value);
 
-    expect(file_get_contents($this->value))->toBe($fileContent);
+    expect(str_replace(PHP_EOL, "\n", file_get_contents($this->value)))->toBe($fileContent);
 
     return $this;
 });


### PR DESCRIPTION
When using `#[Cast(type: 'int')]` for example, I always ran into the following exception:

```
Undefined array key 0
vendor\wendelladriel\laravel-lift\src\Concerns\CastValues.php :106
```