### PR TITLE
fix:Fix static property data bleed in RulesValidation

### DIFF
--- a/src/Concerns/RulesValidation.php
+++ b/src/Concerns/RulesValidation.php
@@ -82,6 +82,16 @@ trait RulesValidation
         return self::formatValidationMessages(self::$modelUpdateMessages);
     }
 
+    protected static function resetValidations(): void
+    {
+        static::$modelRules = null;
+        static::$modelCreateRules = null;
+        static::$modelUpdateRules = null;
+        static::$modelMessages = null;
+        static::$modelCreateMessages = null;
+        static::$modelUpdateMessages = null;
+    }
+
     /**
      * @param  Collection<PropertyInfo>  $properties
      *


### PR DESCRIPTION
Resolve issue where static properties in RulesValidation Trait are shared across multiple classes, causing data bleeding. Added reset method for static properties.

When using the `RulesValidation` Trait, static properties such as `*ValidationRules` and `*ValidationMessages` are shared across multiple classes. This can lead to data bleeding, especially when a Model inherits from another Model that uses the `Lift` Trait and multiple database save operations are triggered in the same request.
### Solution
To resolve this issue, the `resetValidations` method has been added to the `RulesValidation` Trait. This method resets the static properties to their initial state before each operation, preventing data bleeding between different Model instances.
### Changes
- Added `resetValidations` method to the `RulesValidation` Trait.
- Updated all relevant Model calls to invoke `resetValidations` where necessary to ensure data integrity.

This pull request includes changes to improve the consistency and maintainability of the codebase by replacing `self` with `static` in various methods and adding a new method to reset validation messages.

Improvements to method calls:

* [`src/Lift.php`](diffhunk://#diff-712746172719a581b61e3c9081d03cd2ae611eb0acfb45b963226a89367276e6L53-R74): Replaced all instances of `self` with `static` in the `bootLift`, `syncOriginal`, `ignoredProperties`, and `fillProperties` methods to ensure proper method resolution in subclasses. [[1]](diffhunk://#diff-712746172719a581b61e3c9081d03cd2ae611eb0acfb45b963226a89367276e6L53-R74) [[2]](diffhunk://#diff-712746172719a581b61e3c9081d03cd2ae611eb0acfb45b963226a89367276e6L84-R84) [[3]](diffhunk://#diff-712746172719a581b61e3c9081d03cd2ae611eb0acfb45b963226a89367276e6L93-R128) [[4]](diffhunk://#diff-712746172719a581b61e3c9081d03cd2ae611eb0acfb45b963226a89367276e6L139-R151) [[5]](diffhunk://#diff-712746172719a581b61e3c9081d03cd2ae611eb0acfb45b963226a89367276e6L233-R234) [[6]](diffhunk://#diff-712746172719a581b61e3c9081d03cd2ae611eb0acfb45b963226a89367276e6L402-R409)

New functionality:

* [`src/Concerns/RulesValidation.php`](diffhunk://#diff-d4caaa6c69badd4b825f1afdd841550fa1a3c815bcc566a884d2c797bb8d01c2R85-R94): Added a new method `resetValidations` to reset validation messages and rules.

This refactoring enhances the flexibility and reusability of the code by allowing subclasses to override static methods more effectively.