### PR TITLE
feat: allow basic customization of pivot to BelongsToMany attribute

### DIFF
--- a/src/Attributes/Relations/BelongsToMany.php
+++ b/src/Attributes/Relations/BelongsToMany.php
@@ -7,17 +7,29 @@ namespace WendellAdriel\Lift\Attributes\Relations;
 use Attribute;
 use Illuminate\Support\Str;
 use WendellAdriel\Lift\Concerns\HasArguments;
+use WendellAdriel\Lift\Concerns\HasPivot;
+use WendellAdriel\Lift\Contracts\PivotAttribute;
 use WendellAdriel\Lift\Contracts\RelationAttribute;
 
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final class BelongsToMany implements RelationAttribute
+final class BelongsToMany implements PivotAttribute, RelationAttribute
 {
     use HasArguments;
+    use HasPivot;
 
     /**
      * @var class-string
      */
     public string $related;
+
+    public ?string $pivotModel;
+
+    /**
+     * @var array<string>|null
+     */
+    public ?array $pivotColumns;
+
+    public ?bool $pivotTimestamps;
 
     /**
      * @var array<string>
@@ -28,13 +40,16 @@ final class BelongsToMany implements RelationAttribute
 
     /**
      * @param  class-string  $related
-     * @param  array<string>  ...$arguments
+     * @param  array<string>|null  $pivotColumns
      */
-    public function __construct(string $related, ?string $name = null, string ...$arguments)
+    public function __construct(string $related, ?string $name = null, ?string $pivotModel = null, ?array $pivotColumns = null, ?bool $pivotTimestamps = null, string ...$arguments)
     {
         $this->related = $related;
         $this->name = $name;
         $this->arguments = [$related, ...$arguments];
+        $this->pivotModel = $pivotModel;
+        $this->pivotColumns = $pivotColumns;
+        $this->pivotTimestamps = $pivotTimestamps;
     }
 
     public function relationName(): string

--- a/src/Concerns/HasPivot.php
+++ b/src/Concerns/HasPivot.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Concerns;
+
+trait HasPivot
+{
+    public function pivotModel(): ?string
+    {
+        return $this->pivotModel;
+    }
+
+    /**
+     * @return array<string>|null
+     */
+    public function pivotColumns(): ?array
+    {
+        return $this->pivotColumns;
+    }
+
+    public function pivotTimestamps(): ?bool
+    {
+        return $this->pivotTimestamps;
+    }
+}

--- a/src/Contracts/PivotAttribute.php
+++ b/src/Contracts/PivotAttribute.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\Lift\Contracts;
+
+interface PivotAttribute
+{
+    public function pivotModel(): ?string;
+
+    /**
+     * @return array<string>|null
+     */
+    public function pivotColumns(): ?array;
+
+    public function pivotTimestamps(): ?bool;
+}

--- a/tests/Datasets/Organization.php
+++ b/tests/Datasets/Organization.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets;
+
+use Illuminate\Database\Eloquent\Model;
+use Tests\Datasets\Pivot\OrganizationUser;
+use WendellAdriel\Lift\Attributes\Fillable;
+use WendellAdriel\Lift\Attributes\PrimaryKey;
+use WendellAdriel\Lift\Attributes\Relations\BelongsToMany;
+use WendellAdriel\Lift\Lift;
+
+#[BelongsToMany(User::class, pivotModel: OrganizationUser::class, pivotColumns: ['is_owner'])]
+class Organization extends Model
+{
+    use Lift;
+
+    #[PrimaryKey]
+    public int $id;
+
+    #[Fillable]
+    public string $name;
+}

--- a/tests/Datasets/Pivot/OrganizationUser.php
+++ b/tests/Datasets/Pivot/OrganizationUser.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets\Pivot;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class OrganizationUser extends Pivot
+{
+    protected $casts = [
+        'is_owner' => 'boolean',
+    ];
+}

--- a/tests/Datasets/User.php
+++ b/tests/Datasets/User.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Datasets;
 
 use Illuminate\Database\Eloquent\Model;
+use Tests\Datasets\Pivot\OrganizationUser;
 use WendellAdriel\Lift\Attributes\PrimaryKey;
 use WendellAdriel\Lift\Attributes\Relations\BelongsToMany;
 use WendellAdriel\Lift\Attributes\Relations\HasMany;
@@ -14,6 +15,7 @@ use WendellAdriel\Lift\Attributes\Rules;
 use WendellAdriel\Lift\Lift;
 
 #[BelongsToMany(related: Role::class, name: 'roleList')]
+#[BelongsToMany(related: Organization::class, pivotModel: OrganizationUser::class, pivotColumns: ['is_owner'])]
 #[HasMany(related: Post::class, name: 'articles')]
 #[HasMany(WorkBook::class)]
 #[HasOne(Phone::class)]

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -216,6 +216,19 @@ abstract class TestCase extends BaseTestCase
             $table->enum('status', ['draft', 'published', 'archived']);
             $table->timestamps();
         });
+
+        Schema::create('organizations', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('organization_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organization_id')->constrained();
+            $table->foreignId('user_id')->constrained();
+            $table->boolean('is_owner')->default(false);
+        });
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
# What was changed

Added support for basic pivot customization to the `BelongsToMany` attribute.


## Example

```php
#[BelongsToMany(User::class, pivotModel: OrganizationUser::class, pivotColumns: ['is_owner'])]
class Organization extends Model
{
    use Lift;

    #[PrimaryKey]
    public int $id;

    #[Fillable]
    public string $name;
}
```