### PR TITLE
Sync nullable belongs-to foreign keys

### DIFF
--- a/src/Concerns/ManageRelations.php
+++ b/src/Concerns/ManageRelations.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
 use ReflectionAttribute;
 use ReflectionClass;
+use ReflectionException;
 use WendellAdriel\Lift\Attributes\Relations\BelongsTo;
 use WendellAdriel\Lift\Attributes\Relations\BelongsToMany;
 use WendellAdriel\Lift\Contracts\RelationAttribute;
@@ -19,6 +20,17 @@ trait ManageRelations
      * @var array<class-string, RelationAttribute>
      */
     private static ?array $relationsConfig = null;
+
+    public function setAttribute($key, $value)
+    {
+        $model = parent::setAttribute($key, $value);
+
+        if (is_string($key)) {
+            self::syncBelongsToForeignKeyProperty($this, $key);
+        }
+
+        return $model;
+    }
 
     /**
      * @return array<class-string, RelationAttribute>
@@ -47,6 +59,11 @@ trait ManageRelations
                 $relation->relationName(),
                 function (Model $model) use ($relation, $relationArguments, &$relationObject): Relation {
                     $method = lcfirst(class_basename(get_class($relation)));
+
+                    if ($relation instanceof BelongsTo) {
+                        self::syncBelongsToForeignKeyProperty($model, $relationArguments[1], false);
+                    }
+
                     $relationObject = $model->{$method}(...$relationArguments);
 
                     if ($relation instanceof BelongsToMany) {
@@ -79,9 +96,50 @@ trait ManageRelations
             $related = new $relatedClass();
 
             $foreignKey = $relationConfig->relationArguments()[1] ?? Str::snake($relationConfig->relationName()) . '_' . $related->getKeyName();
-            if (! isset($model->{$foreignKey}) || blank($model->{$foreignKey})) {
-                $model->{$foreignKey} = $model->getAttribute($foreignKey);
+            self::syncBelongsToForeignKeyProperty($model, $foreignKey, false);
+        }
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    private static function syncBelongsToForeignKeyProperty(Model $model, string $foreignKey, bool $checkRelation = true): void
+    {
+        if ($checkRelation && ! self::isBelongsToForeignKey($model, $foreignKey)) {
+            return;
+        }
+
+        $classReflection = new ReflectionClass($model);
+        if (! $classReflection->hasProperty($foreignKey)) {
+            return;
+        }
+
+        $property = $classReflection->getProperty($foreignKey);
+        if (! $property->isPublic()) {
+            return;
+        }
+
+        $value = $model->getAttribute($foreignKey);
+        $type = $property->getType();
+        if ($value === null && $type !== null && ! $type->allowsNull()) {
+            return;
+        }
+
+        if ($property->isInitialized($model) && $model->{$foreignKey} === $value) {
+            return;
+        }
+
+        $model->{$foreignKey} = $value;
+    }
+
+    private static function isBelongsToForeignKey(Model $model, string $foreignKey): bool
+    {
+        foreach (self::relationsConfig($model) as $relationConfig) {
+            if (($relationConfig->relationArguments()[1] ?? null) === $foreignKey) {
+                return true;
             }
         }
+
+        return false;
     }
 }

--- a/tests/Datasets/NullableConfigPost.php
+++ b/tests/Datasets/NullableConfigPost.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets;
+
+use Illuminate\Database\Eloquent\Model;
+use WendellAdriel\Lift\Attributes\Config;
+use WendellAdriel\Lift\Attributes\DB;
+use WendellAdriel\Lift\Attributes\PrimaryKey;
+use WendellAdriel\Lift\Attributes\Relations\BelongsTo;
+use WendellAdriel\Lift\Lift;
+
+#[DB(table: 'posts')]
+#[BelongsTo(related: User::class, name: 'author')]
+class NullableConfigPost extends Model
+{
+    use Lift;
+
+    #[PrimaryKey]
+    public int $id;
+
+    #[Config(fillable: true, rules: ['required', 'string'])]
+    public string $title;
+
+    #[Config(fillable: true, rules: ['required', 'string'])]
+    public string $content;
+
+    #[Config(fillable: true, rules: ['nullable', 'integer'], cast: 'integer', default: null)]
+    public ?int $user_id;
+}

--- a/tests/Feature/RelationsTest.php
+++ b/tests/Feature/RelationsTest.php
@@ -10,6 +10,7 @@ use Tests\Datasets\Image;
 use Tests\Datasets\Library;
 use Tests\Datasets\LibraryBook;
 use Tests\Datasets\Manufacturer;
+use Tests\Datasets\NullableConfigPost;
 use Tests\Datasets\Organization;
 use Tests\Datasets\Phone;
 use Tests\Datasets\Post;
@@ -81,6 +82,63 @@ it('loads BelongsTo relation', function () {
 
     $postWithoutUser = Post::query()->find($postWithoutUser->id);
     expect($postWithoutUser->author)->toBeNull();
+});
+
+it('treats a fresh nullable config BelongsTo foreign key as null', function () {
+    $post = new NullableConfigPost();
+    $author = null;
+
+    try {
+        $author = $post->author;
+    } catch (Error $error) {
+        expect($error->getMessage())->not->toContain('must not be accessed before initialization');
+
+        throw $error;
+    }
+
+    expect($author)->toBeNull()
+        ->and($post->user_id)->toBeNull()
+        ->and($post->getAttribute('user_id'))->toBeNull();
+});
+
+it('syncs a nullable config BelongsTo foreign key when associating', function () {
+    $user = User::create([
+        'name' => fake()->name,
+        'email' => fake()->unique()->safeEmail,
+        'password' => 's3Cr3T@!!!',
+    ]);
+
+    $post = new NullableConfigPost();
+    $post->title = fake()->sentence;
+    $post->content = fake()->paragraph;
+
+    $post->author()->associate($user);
+
+    expect($post->user_id)->toBe($user->id)
+        ->and($post->getAttribute('user_id'))->toBe($user->id);
+
+    $post->save();
+
+    $this->assertDatabaseHas(NullableConfigPost::class, [
+        'id' => $post->id,
+        'user_id' => $user->id,
+    ]);
+});
+
+it('saves a nullable config BelongsTo foreign key without association', function () {
+    $post = new NullableConfigPost();
+    $post->title = fake()->sentence;
+    $post->content = fake()->paragraph;
+
+    expect($post->save())->toBeTrue()
+        ->and($post->author)->toBeNull()
+        ->and($post->user_id)->toBeNull()
+        ->and($post->getAttribute('user_id'))->toBeNull();
+
+    $this->assertDatabaseHas(NullableConfigPost::class, [
+        'id' => $post->id,
+        'user_id' => null,
+    ]);
 });
 
 it('loads BelongsToMany relation', function () {


### PR DESCRIPTION
Nullable typed foreign key properties on BelongsTo relations could be read before Laravel had synced the model attribute value, causing an uninitialized property error on fresh models or association.

This keeps the public foreign key property in sync with the Eloquent attribute value when reading the relation or assigning the key, while preserving null handling for nullable config fields.

Fixes #92