### PR TITLE
Fix fillable mapped columns

### DIFF
--- a/src/Concerns/AttributesGuard.php
+++ b/src/Concerns/AttributesGuard.php
@@ -53,9 +53,13 @@ trait AttributesGuard
     private function applyAttributesGuard(Collection $properties): void
     {
         $this->mergeGuarded(['*']);
+        $customColumns = self::customColumns();
 
         $fillableProperties = self::getPropertiesForAttributes($properties, [Fillable::class]);
-        $this->mergeFillable($fillableProperties->map(fn ($property) => $property->name)->values()->toArray());
+        $this->mergeFillable($fillableProperties
+            ->flatMap(fn ($property) => array_unique([$property->name, $customColumns[$property->name] ?? $property->name]))
+            ->values()
+            ->toArray());
 
         $hiddenProperties = self::getPropertiesForAttributes($properties, [Hidden::class]);
         $this->makeHidden($hiddenProperties->map(fn ($property) => $property->name)->values()->toArray());
@@ -74,7 +78,9 @@ trait AttributesGuard
     private function buildLiftList(Collection $properties, string $attributeProperty): array
     {
         $result = [];
-        $properties->each(function ($property) use (&$result, $attributeProperty) {
+        $customColumns = $attributeProperty === 'fillable' ? self::customColumns() : [];
+
+        $properties->each(function ($property) use (&$result, $attributeProperty, $customColumns) {
             $configAttribute = $property->attributes->first(fn ($attribute) => $attribute->getName() === Config::class);
             if (blank($configAttribute)) {
                 return;
@@ -83,9 +89,13 @@ trait AttributesGuard
             $configAttribute = $configAttribute->newInstance();
             if ($configAttribute->{$attributeProperty}) {
                 $result[] = $property->name;
+
+                if (isset($customColumns[$property->name])) {
+                    $result[] = $customColumns[$property->name];
+                }
             }
         });
 
-        return $result;
+        return array_values(array_unique($result));
     }
 }

--- a/src/Concerns/DatabaseConfigurations.php
+++ b/src/Concerns/DatabaseConfigurations.php
@@ -82,6 +82,10 @@ trait DatabaseConfigurations
         $customColumns = self::customColumns();
 
         foreach ($publicProperties as $property) {
+            if (isset($customColumns[$property]) && $model->isDirty($customColumns[$property]) && ! blank($model->getAttribute($customColumns[$property]))) {
+                $model->{$property} = $model->getAttribute($customColumns[$property]);
+            }
+
             if (! blank($model->getAttribute($property)) && isset($customColumns[$property])) {
                 $model->{$property} = $model->getAttribute($property);
                 unset($model->attributes[$property]);

--- a/tests/Datasets/UserConfigColumn.php
+++ b/tests/Datasets/UserConfigColumn.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets;
+
+use Illuminate\Database\Eloquent\Model;
+use WendellAdriel\Lift\Attributes\Config;
+use WendellAdriel\Lift\Attributes\DB;
+use WendellAdriel\Lift\Lift;
+
+#[DB(table: 'users')]
+class UserConfigColumn extends Model
+{
+    use Lift;
+
+    #[Config(fillable: true)]
+    public string $name;
+
+    #[Config(fillable: true, column: 'email')]
+    public string $user_email;
+
+    #[Config(fillable: true, column: 'password')]
+    public string $user_password;
+}

--- a/tests/Feature/ColumnTest.php
+++ b/tests/Feature/ColumnTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Tests\Datasets\UserColumn;
+use Tests\Datasets\UserConfigColumn;
 
 it('returns model custom columns', function () {
     expect(UserColumn::customColumns())->toBe([
@@ -94,6 +95,33 @@ describe('creates new model with custom columns', function () {
         ]);
     });
 
+    it('creates model with create method using mapped database columns', function () {
+        $user = UserColumn::create([
+            'name' => fake()->name,
+            'email' => 'john.doe@example.com',
+            'password' => 's3Cr3T@!!!',
+        ]);
+
+        $this->assertDatabaseCount(UserColumn::class, 1);
+        $this->assertDatabaseHas(UserColumn::class, [
+            'name' => $user->name,
+            'email' => 'john.doe@example.com',
+            'password' => 's3Cr3T@!!!',
+        ]);
+    });
+
+    it('ignores unrelated non-fillable keys when using mapped database columns', function () {
+        $user = new UserColumn();
+        $user->fill([
+            'name' => fake()->name,
+            'email' => 'john.doe@example.com',
+            'password' => 's3Cr3T@!!!',
+            'not_fillable' => 'ignored',
+        ]);
+
+        expect($user->getAttributes())->not->toHaveKey('not_fillable');
+    });
+
     it('creates model with default values', function () {
         UserColumn::create([
             'user_email' => 'john.doe@example.com',
@@ -147,6 +175,27 @@ describe('updates model with custom columns', function () {
         ]);
     });
 
+    it('updates model with fill method using mapped database columns', function () {
+        $user = UserColumn::create([
+            'name' => fake()->name,
+            'user_email' => fake()->unique()->safeEmail,
+            'user_password' => 's3Cr3T@!!!',
+        ]);
+
+        $user->fill([
+            'name' => 'John Doe',
+            'email' => 'john.doe@example.com',
+        ]);
+        $user->save();
+
+        $this->assertDatabaseCount(UserColumn::class, 1);
+        $this->assertDatabaseHas(UserColumn::class, [
+            'name' => 'John Doe',
+            'email' => 'john.doe@example.com',
+            'password' => 's3Cr3T@!!!',
+        ]);
+    });
+
     it('updates model with update method', function () {
         $user = UserColumn::create([
             'name' => fake()->name,
@@ -166,6 +215,41 @@ describe('updates model with custom columns', function () {
             'password' => 's3Cr3T@!!!',
         ]);
     });
+
+    it('updates model with update method using mapped database columns', function () {
+        $user = UserColumn::create([
+            'name' => fake()->name,
+            'user_email' => fake()->unique()->safeEmail,
+            'user_password' => 's3Cr3T@!!!',
+        ]);
+
+        $user->update([
+            'name' => 'John Doe',
+            'email' => 'john.doe@example.com',
+        ]);
+
+        $this->assertDatabaseCount(UserColumn::class, 1);
+        $this->assertDatabaseHas(UserColumn::class, [
+            'name' => 'John Doe',
+            'email' => 'john.doe@example.com',
+            'password' => 's3Cr3T@!!!',
+        ]);
+    });
+});
+
+it('creates model with Config fillable mapped database columns', function () {
+    $user = UserConfigColumn::create([
+        'name' => 'John Doe',
+        'email' => 'john.doe@example.com',
+        'password' => 's3Cr3T@!!!',
+    ]);
+
+    $this->assertDatabaseCount(UserConfigColumn::class, 1);
+    $this->assertDatabaseHas(UserConfigColumn::class, [
+        'name' => $user->name,
+        'email' => 'john.doe@example.com',
+        'password' => 's3Cr3T@!!!',
+    ]);
 });
 
 it('retrieves model with all custom columns and properties set', function () {


### PR DESCRIPTION
When a Lift model property uses \`#[Fillable]\` with a custom column mapping, Laravel should accept the database column name during mass assignment. This fixes the generated fillable list so mapped column names work for \`create()\`, \`fill()\`, and \`update()\`, while keeping the existing property-name behavior intact.

Fixes #98