### PR TITLE
Initialize default public properties

### DIFF
--- a/docs/attributes/column.md
+++ b/docs/attributes/column.md
@@ -26,6 +26,8 @@ final class Product extends Model
 
 You can also set a default value for your **public properties** using the `Column` attribute. In the example below the `price` property will be mapped to the `price` column on the database table and will have a default value of `0.0`:
 
+Default values are applied when an uninitialized public property is omitted while filling a model, before saving a model, and when a retrieved model does not include the backing column in a partial select.
+
 ```php
 use Illuminate\Database\Eloquent\Model;
 use WendellAdriel\Lift\Attributes\Cast;

--- a/docs/getting-started/changelog.md
+++ b/docs/getting-started/changelog.md
@@ -2,6 +2,10 @@
 
 Here's a quick overview of the new features in the latest versions of the package.
 
+## v0.19.1
+
+* Fixed default values for public properties so they are initialized after `castAndFill` and when omitted from partial selects.
+
 ## v0.19.0
 
 * Added support for complex validation rules using model methods.

--- a/docs/methods/castandfill.md
+++ b/docs/methods/castandfill.md
@@ -2,6 +2,8 @@
 
 A replacement for the `fill` method. It will cast your public properties and fill the model instance.
 
+If a public property has a default value configured with `Column` or `Config` and that property is omitted from the given data, `castAndFill` will initialize the property with its default value.
+
 ```php
 $product = new Product();
 $product->castAndFill([

--- a/src/Concerns/CastValues.php
+++ b/src/Concerns/CastValues.php
@@ -36,6 +36,8 @@ trait CastValues
                 : $value;
         }
 
+        self::applyDefaultValues($this);
+
         return $this;
     }
 

--- a/src/Concerns/DatabaseConfigurations.php
+++ b/src/Concerns/DatabaseConfigurations.php
@@ -92,12 +92,10 @@ trait DatabaseConfigurations
             }
 
             if (
-                (! isset($model->{$property}) || blank($model->{$property})) &&
-                isset($defaultValues[$property])
+                ! isset($model->{$property}) &&
+                array_key_exists($property, $defaultValues)
             ) {
-                $model->{$property} = is_string($defaultValues[$property]) && method_exists($model, $defaultValues[$property])
-                    ? $model->{$defaultValues[$property]}()
-                    : $defaultValues[$property];
+                $model->{$property} = self::resolveDefaultValue($model, $defaultValues[$property]);
             }
 
             if (! isset($model->{$property})) {
@@ -118,9 +116,35 @@ trait DatabaseConfigurations
 
     private static function syncColumnsToCustom(Model $model): void
     {
+        $attributes = $model->getAttributes();
+
         foreach (self::customColumns() as $property => $column) {
-            $model->{$property} = $model->getAttribute($column);
+            if (array_key_exists($column, $attributes)) {
+                $model->{$property} = $model->getAttribute($column);
+            }
         }
+    }
+
+    private static function applyDefaultValues(Model $model): void
+    {
+        $defaultValues = self::defaultValues();
+
+        foreach (self::getModelPublicReflectionProperties($model) as $property) {
+            $propertyName = $property->getName();
+
+            if (! array_key_exists($propertyName, $defaultValues) || $property->isInitialized($model)) {
+                continue;
+            }
+
+            $model->{$propertyName} = self::resolveDefaultValue($model, $defaultValues[$propertyName]);
+        }
+    }
+
+    private static function resolveDefaultValue(Model $model, mixed $defaultValue): mixed
+    {
+        return is_string($defaultValue) && method_exists($model, $defaultValue)
+            ? $model->{$defaultValue}()
+            : $defaultValue;
     }
 
     private function applyDatabaseConfigurations(): void

--- a/src/Lift.php
+++ b/src/Lift.php
@@ -403,5 +403,6 @@ trait Lift
         }
 
         self::syncColumnsToCustom($model);
+        self::applyDefaultValues($model);
     }
 }

--- a/tests/Feature/ColumnTest.php
+++ b/tests/Feature/ColumnTest.php
@@ -48,6 +48,31 @@ it('returns json with model properties when custom columns are defined', functio
 });
 
 describe('creates new model with custom columns', function () {
+    it('initializes default public properties when cast and fill omits them', function () {
+        $user = new UserColumn();
+        $user->castAndFill([
+            'user_email' => 'john.doe@example.com',
+        ]);
+
+        expect($user->name)->toBe('John Doe')
+            ->and($user->active)->toBeFalse()
+            ->and($user->user_password)->toBe('s3Cr3tP4ssw0rd@!!!');
+    });
+
+    it('keeps explicitly filled public properties over defaults when cast and fill is used', function () {
+        $user = new UserColumn();
+        $user->castAndFill([
+            'name' => 'Jane Doe',
+            'user_email' => 'john.doe@example.com',
+            'user_password' => 's3Cr3T@!!!',
+            'active' => true,
+        ]);
+
+        expect($user->name)->toBe('Jane Doe')
+            ->and($user->active)->toBeTrue()
+            ->and($user->user_password)->toBe('s3Cr3T@!!!');
+    });
+
     it('creates model with individual properties set', function () {
         $user = new UserColumn();
         $user->name = fake()->name;
@@ -265,4 +290,21 @@ it('retrieves model with all custom columns and properties set', function () {
         ->and($user->user_password)->toBe('s3Cr3T@!!!')
         ->and($user->email)->toBe('john.doe@example.com')
         ->and($user->password)->toBe('s3Cr3T@!!!');
+});
+
+it('initializes default public properties omitted from partial selects', function () {
+    UserColumn::create([
+        'name' => 'Jane Doe',
+        'user_email' => 'john.doe@example.com',
+        'user_password' => 's3Cr3T@!!!',
+    ]);
+
+    $user = UserColumn::query()
+        ->select(['id', 'email'])
+        ->first();
+
+    expect($user->name)->toBe('John Doe')
+        ->and($user->active)->toBeFalse()
+        ->and($user->user_password)->toBe('s3Cr3tP4ssw0rd@!!!')
+        ->and($user->user_email)->toBe('john.doe@example.com');
 });


### PR DESCRIPTION
Default values configured with `Column` or `Config` were only applied during the save flow, so omitted typed public properties could still fail after `castAndFill` or when a model was retrieved with a partial select.

This applies configured defaults when public properties are still uninitialized after filling or hydration, keeps explicit values intact, and documents the behavior in the changelog and relevant docs.

Fixes #101